### PR TITLE
🧪 [testing improvement] Add unit tests for MCP query tool logic and f…

### DIFF
--- a/packages/mcp/src/tools/query.ts
+++ b/packages/mcp/src/tools/query.ts
@@ -134,7 +134,7 @@ export async function handleKbQuery(
  * Input: "[[a,b,c],[d,e,f]]"
  * Output: [["a", "b", "c"], ["d", "e", "f"]]
  */
-function parseListOfLists(listStr: string): string[][] {
+export function parseListOfLists(listStr: string): string[][] {
   const cleaned = listStr.trim().replace(/^\[/, "").replace(/\]$/, "");
 
   if (cleaned === "") {
@@ -185,7 +185,7 @@ function parseListOfLists(listStr: string): string[][] {
  * Parse a single entity from Prolog binding format.
  * Input: "[abc123, req, [id=abc123, title=\"Test\", ...]]"
  */
-function parseEntityFromBinding(bindingStr: string): Record<string, unknown> {
+export function parseEntityFromBinding(bindingStr: string): Record<string, unknown> {
   const cleaned = bindingStr.trim().replace(/^\[/, "").replace(/\]$/, "");
   const parts = splitTopLevel(cleaned, ",");
 
@@ -205,7 +205,7 @@ function parseEntityFromBinding(bindingStr: string): Record<string, unknown> {
  * Parse entity from array returned by parseListOfLists.
  * Input: ["abc123", "req", "[id=abc123, title=\"Test\", ...]"]
  */
-function parseEntityFromList(data: string[]): Record<string, unknown> {
+export function parseEntityFromList(data: string[]): Record<string, unknown> {
   if (data.length < 3) {
     return {};
   }
@@ -221,7 +221,7 @@ function parseEntityFromList(data: string[]): Record<string, unknown> {
 /**
  * Parse Prolog property list into JavaScript object.
  */
-function parsePropertyList(propsStr: string): Record<string, unknown> {
+export function parsePropertyList(propsStr: string): Record<string, unknown> {
   const props: Record<string, unknown> = {};
 
   let cleaned = propsStr.trim();
@@ -255,7 +255,7 @@ function parsePropertyList(propsStr: string): Record<string, unknown> {
 /**
  * Parse a single Prolog value, handling typed literals and URIs.
  */
-function parsePrologValue(valueInput: string): unknown {
+export function parsePrologValue(valueInput: string): unknown {
   const value = valueInput.trim();
 
   // Handle typed literal: ^^("value", type)
@@ -289,7 +289,7 @@ function parsePrologValue(valueInput: string): unknown {
         if (listContent === "") {
           return [];
         }
-        return listContent.split(",").map((item) => item.trim());
+        return splitTopLevel(listContent, ",").map((item) => item.trim());
       }
 
       return literalValue;
@@ -321,7 +321,7 @@ function parsePrologValue(valueInput: string): unknown {
     if (listContent === "") {
       return [];
     }
-    const items = listContent.split(",").map((item) => {
+    const items = splitTopLevel(listContent, ",").map((item) => {
       return parsePrologValue(item.trim());
     });
     return items;
@@ -333,7 +333,7 @@ function parsePrologValue(valueInput: string): unknown {
 /**
  * Split a string by delimiter at the top level (not inside brackets or quotes).
  */
-function splitTopLevel(str: string, delimiter: string): string[] {
+export function splitTopLevel(str: string, delimiter: string): string[] {
   const results: string[] = [];
   let current = "";
   let depth = 0;

--- a/packages/mcp/tests/tools/query.test.ts
+++ b/packages/mcp/tests/tools/query.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, test, mock } from "bun:test";
+import {
+  handleKbQuery,
+  splitTopLevel,
+  parsePrologValue,
+  parsePropertyList,
+  parseListOfLists,
+  parseEntityFromBinding,
+  parseEntityFromList
+} from "../../src/tools/query.js";
+import { PrologProcess } from "@kibi/cli/src/prolog.js";
+
+describe("MCP kb.query Parsing Functions", () => {
+  describe("splitTopLevel", () => {
+    test("should split simple strings", () => {
+      expect(splitTopLevel("a,b,c", ",")).toEqual(["a", "b", "c"]);
+    });
+
+    test("should not split inside brackets", () => {
+      expect(splitTopLevel("a,[b,c],d", ",")).toEqual(["a", "[b,c]", "d"]);
+    });
+
+    test("should not split inside quotes", () => {
+      expect(splitTopLevel('a,"b,c",d', ",")).toEqual(["a", '"b,c"', "d"]);
+    });
+
+    test("should handle nested structures", () => {
+      expect(splitTopLevel("a,[b,(c,d)],e", ",")).toEqual(["a", "[b,(c,d)]", "e"]);
+    });
+
+    test("should handle escaped quotes", () => {
+      // splitTopLevel handles escaped quotes by checking prevChar !== "\\"
+      expect(splitTopLevel('a,"b\\"c,d",e', ",")).toEqual(["a", '"b\\"c,d"', "e"]);
+    });
+  });
+
+  describe("parsePrologValue", () => {
+    test("should parse simple strings and atoms", () => {
+      expect(parsePrologValue('"hello"')).toBe("hello");
+      expect(parsePrologValue("'world'")).toBe("world");
+      expect(parsePrologValue("atom")).toBe("atom");
+    });
+
+    test("should parse URIs", () => {
+      expect(parsePrologValue("file:///path/to/file.md")).toBe("file.md");
+    });
+
+    test("should parse typed literals", () => {
+      expect(parsePrologValue('^^("2023-01-01", "date")')).toBe("2023-01-01");
+      expect(parsePrologValue('^^("[tag1,tag2]", "list")')).toEqual(["tag1", "tag2"]);
+      expect(parsePrologValue('^^("[]", "list")')).toEqual([]);
+    });
+
+    test("should parse lists", () => {
+      expect(parsePrologValue("[a, b, c]")).toEqual(["a", "b", "c"]);
+      expect(parsePrologValue("[]")).toEqual([]);
+      expect(parsePrologValue('["a", "b"]')).toEqual(["a", "b"]);
+    });
+
+    test("should handle nested lists", () => {
+       expect(parsePrologValue("[a, [b, c]]")).toEqual(["a", ["b", "c"]]);
+    });
+  });
+
+  describe("parsePropertyList", () => {
+    test("should parse simple property lists", () => {
+      const input = "[id=1, title=\"Test\"]";
+      expect(parsePropertyList(input)).toEqual({
+        id: "1",
+        title: "Test"
+      });
+    });
+
+    test("should skip ellipsis", () => {
+      const input = "[id=1, ...]";
+      expect(parsePropertyList(input)).toEqual({
+        id: "1"
+      });
+    });
+
+    test("should handle nested structures in values", () => {
+      const input = "[id=1, tags=[a, b]]";
+      expect(parsePropertyList(input)).toEqual({
+        id: "1",
+        tags: ["a", "b"]
+      });
+    });
+  });
+
+  describe("parseListOfLists", () => {
+    test("should parse empty list", () => {
+      expect(parseListOfLists("[]")).toEqual([]);
+    });
+
+    test("should parse single list", () => {
+      expect(parseListOfLists("[[a,b,c]]")).toEqual([["a", "b", "c"]]);
+    });
+
+    test("should parse multiple lists", () => {
+      expect(parseListOfLists("[[a,b,c],[d,e,f]]")).toEqual([["a", "b", "c"], ["d", "e", "f"]]);
+    });
+
+    test("should handle complex elements", () => {
+      const input = "[[id1, type1, [prop=val]], [id2, type2, [prop2=val2]]]";
+      expect(parseListOfLists(input)).toEqual([
+        ["id1", "type1", "[prop=val]"],
+        ["id2", "type2", "[prop2=val2]"]
+      ]);
+    });
+  });
+
+  describe("parseEntityFromBinding and parseEntityFromList", () => {
+    test("parseEntityFromBinding should parse binding string", () => {
+      const input = "[abc123, req, [title=\"Test\"]]";
+      expect(parseEntityFromBinding(input)).toEqual({
+        id: "abc123",
+        type: "req",
+        title: "Test"
+      });
+    });
+
+    test("parseEntityFromList should parse data array", () => {
+      const data = ["abc123", "req", "[title=\"Test\"]"];
+      expect(parseEntityFromList(data)).toEqual({
+        id: "abc123",
+        type: "req",
+        title: "Test"
+      });
+    });
+  });
+
+  describe("handleKbQuery", () => {
+    const mockProlog = {
+      query: mock(async () => ({ success: true, bindings: {} }))
+    } as unknown as PrologProcess;
+
+    test("should generate correct goal for all entities", async () => {
+      (mockProlog.query as any).mockResolvedValueOnce({
+        success: true,
+        bindings: { Results: "[]" }
+      });
+
+      await handleKbQuery(mockProlog, {});
+      expect(mockProlog.query).toHaveBeenCalledWith(
+        "findall([Id,Type,Props], kb_entity(Id, Type, Props), Results)"
+      );
+    });
+
+    test("should generate correct goal for type filter", async () => {
+      (mockProlog.query as any).mockResolvedValueOnce({
+        success: true,
+        bindings: { Results: "[]" }
+      });
+
+      await handleKbQuery(mockProlog, { type: "req" });
+      expect(mockProlog.query).toHaveBeenCalledWith(
+        "findall([Id,'req',Props], kb_entity(Id, 'req', Props), Results)"
+      );
+    });
+
+    test("should generate correct goal for id and type filter", async () => {
+      (mockProlog.query as any).mockResolvedValueOnce({
+        success: true,
+        bindings: { Result: "[id1, req, [title=\"T\"]]" }
+      });
+
+      await handleKbQuery(mockProlog, { id: "id1", type: "req" });
+      expect(mockProlog.query).toHaveBeenCalledWith(
+        "kb_entity('id1', 'req', Props), Id = 'id1', Type = 'req', Result = [Id, Type, Props]"
+      );
+    });
+
+    test("should generate correct goal for tags filter", async () => {
+      (mockProlog.query as any).mockResolvedValueOnce({
+        success: true,
+        bindings: { Results: "[]" }
+      });
+
+      await handleKbQuery(mockProlog, { tags: ["t1", "t2"] });
+      expect(mockProlog.query).toHaveBeenCalledWith(
+        "findall([Id,Type,Props], (kb_entity(Id, Type, Props), memberchk(tags=Tags, Props), member(Tag, Tags), member(Tag, ['t1','t2'])), Results)"
+      );
+    });
+
+    test("should handle pagination (limit/offset)", async () => {
+      const entities = Array.from({ length: 10 }, (_, i) =>
+        `[id${i}, req, [title=\"T${i}\", status=\"active\"]]`
+      );
+      (mockProlog.query as any).mockResolvedValueOnce({
+        success: true,
+        bindings: { Results: `[${entities.join(",")}]` }
+      });
+
+      const result = await handleKbQuery(mockProlog, { limit: 2, offset: 3 });
+
+      expect(result.structuredContent?.count).toBe(10);
+      expect(result.structuredContent?.entities.length).toBe(2);
+      expect(result.structuredContent?.entities[0].id).toBe("id3");
+      expect(result.structuredContent?.entities[1].id).toBe("id4");
+    });
+
+    test("should throw error on query failure", async () => {
+      (mockProlog.query as any).mockResolvedValueOnce({
+        success: false,
+        error: "Prolog Error"
+      });
+
+      await expect(handleKbQuery(mockProlog, {})).rejects.toThrow(/Query execution failed: Prolog Error/);
+    });
+
+    test("should throw error on invalid type", async () => {
+      await expect(handleKbQuery(mockProlog, { type: "invalid" as any }))
+        .rejects.toThrow(/Invalid type 'invalid'/);
+    });
+  });
+});


### PR DESCRIPTION
…ix parsing bug

- Exported internal parsing functions in `packages/mcp/src/tools/query.ts` for unit testing.
- Created `packages/mcp/tests/tools/query.test.ts` with comprehensive unit tests for parsing and query goal generation.
- Identified and fixed a bug where nested Prolog lists were incorrectly parsed due to simple comma splitting.
- Fixed inconsistent parsing logic for typed literals.
- Verified all new tests pass and handle edge cases like nested structures and escaped quotes.