### PR TITLE
feat(cursor,mcp,ci): speed MCP tests, quiet stop hook, publish kibi-c…

### DIFF
--- a/.changeset/cursor-stop-hook-quiet.md
+++ b/.changeset/cursor-stop-hook-quiet.md
@@ -1,0 +1,10 @@
+---
+"kibi-cursor": patch
+---
+
+Cursor stop hooks no longer inject a long multi-line Kibi freshness reminder after every agent response. Follow-ups are now one line, and most sessions stay silent.
+
+- Track `kb_upsert`, `kb_delete`, and `kb_check` MCP usage during the session.
+- Emit no stop follow-up when nothing KB-relevant changed, or when `kb_check` already ran after edits.
+- Emit a short summary (`Kibi KB updated (kb_upsert).`) after KB mutations, or a single-line sync nudge when source files changed without KB activity.
+- Fix publish workflow to build and pack `kibi-cursor` tarballs before npm publish.

--- a/.changeset/mcp-integration-prolog-tests.md
+++ b/.changeset/mcp-integration-prolog-tests.md
@@ -1,0 +1,8 @@
+---
+"kibi-mcp": patch
+---
+
+MCP integration tests that exercise kb.pl directly now reuse one persistent SWI-Prolog session instead of spawning a new process on every query under Bun. That cuts wall-clock time for the heaviest suites (for example `check.test.ts`) without changing test semantics.
+
+- Add `packages/mcp/tests/helpers/integration-prolog.ts` with `startIntegrationProlog` / `stopIntegrationProlog` helpers.
+- Migrate check, CRUD, upsert, and transaction-integrity integration tests to the shared-session fixture.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,8 @@ jobs:
         run: bun run build:mcp
       - name: Build Codex plugin package
         run: bun run build:codex
+      - name: Build Cursor plugin package
+        run: bun run build:cursor
       - name: Build and package VS Code extension
         run: bun run --cwd packages/vscode package
       - name: Clean stale tarballs
@@ -102,6 +104,7 @@ jobs:
           cd ../mcp && npm pack
           cd ../opencode && npm pack
           cd ../codex && npm pack
+          cd ../cursor && npm pack
       - name: Upload package tarballs
         uses: actions/upload-artifact@v6
         with:
@@ -112,6 +115,7 @@ jobs:
             packages/mcp/*.tgz
             packages/opencode/*.tgz
             packages/codex/*.tgz
+            packages/cursor/*.tgz
           retention-days: 1
       - name: Upload VS Code extension VSIX
         uses: actions/upload-artifact@v6

--- a/documentation/symbol-coordinates.yaml
+++ b/documentation/symbol-coordinates.yaml
@@ -1943,27 +1943,27 @@ coordinates:
   SYM-cursor-BOOTSTRAP_REMINDER:
     sourceColumn: 13
     sourceEndColumn: 164
-    sourceEndLine: 3
-    sourceFile: packages/cursor/src/messages.ts
-    sourceLine: 2
-  SYM-cursor-CursorHookResult:
-    sourceColumn: 12
-    sourceEndColumn: 2
-    sourceEndLine: 35
-    sourceFile: packages/cursor/src/hook-runner.ts
-    sourceLine: 29
-  SYM-cursor-DIRECT_KB_EDIT_WARNING:
-    sourceColumn: 13
-    sourceEndColumn: 112
     sourceEndLine: 6
     sourceFile: packages/cursor/src/messages.ts
     sourceLine: 5
+  SYM-cursor-CursorHookResult:
+    sourceColumn: 12
+    sourceEndColumn: 2
+    sourceEndLine: 37
+    sourceFile: packages/cursor/src/hook-runner.ts
+    sourceLine: 31
+  SYM-cursor-DIRECT_KB_EDIT_WARNING:
+    sourceColumn: 13
+    sourceEndColumn: 112
+    sourceEndLine: 9
+    sourceFile: packages/cursor/src/messages.ts
+    sourceLine: 8
   SYM-cursor-HookEnvironment:
     sourceColumn: 12
     sourceEndColumn: 2
-    sourceEndLine: 39
+    sourceEndLine: 41
     sourceFile: packages/cursor/src/hook-runner.ts
-    sourceLine: 37
+    sourceLine: 39
   SYM-cursor-HookEvent:
     sourceColumn: 12
     sourceEndColumn: 11
@@ -1979,7 +1979,7 @@ coordinates:
   SYM-cursor-HookState:
     sourceColumn: 12
     sourceEndColumn: 2
-    sourceEndLine: 19
+    sourceEndLine: 21
     sourceFile: packages/cursor/src/hook-state.ts
     sourceLine: 15
   SYM-cursor-adapterKind:
@@ -1991,39 +1991,51 @@ coordinates:
   SYM-cursor-addDirtyPaths:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 252
+    sourceEndLine: 264
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 242
+    sourceLine: 254
   SYM-cursor-clearDirtyPaths:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 302
+    sourceEndLine: 344
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 290
+    sourceLine: 342
+  SYM-cursor-clearSessionHookState:
+    sourceColumn: 16
+    sourceEndColumn: 1
+    sourceEndLine: 339
+    sourceFile: packages/cursor/src/hook-state.ts
+    sourceLine: 329
   SYM-cursor-extractExplicitPathFields:
     sourceColumn: 16
     sourceEndColumn: 1
     sourceEndLine: 101
     sourceFile: packages/cursor/src/path-policy.ts
     sourceLine: 97
+  SYM-cursor-extractKbMcpToolName:
+    sourceColumn: 16
+    sourceEndColumn: 1
+    sourceEndLine: 49
+    sourceFile: packages/cursor/src/kb-mcp-tools.ts
+    sourceLine: 20
   SYM-cursor-freshnessReminder:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 19
+    sourceEndLine: 32
     sourceFile: packages/cursor/src/messages.ts
-    sourceLine: 8
+    sourceLine: 28
   SYM-cursor-hasGuidedPath:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 288
+    sourceEndLine: 300
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 279
+    sourceLine: 291
   SYM-cursor-hookRunnerPath:
     sourceColumn: 13
     sourceEndColumn: 60
-    sourceEndLine: 229
+    sourceEndLine: 243
     sourceFile: packages/cursor/src/hook-runner.ts
-    sourceLine: 229
+    sourceLine: 243
   SYM-cursor-isDirectKbPath:
     sourceColumn: 16
     sourceEndColumn: 1
@@ -2033,9 +2045,15 @@ coordinates:
   SYM-cursor-isDocumentationTrackedPath:
     sourceColumn: 16
     sourceEndColumn: 1
+    sourceEndLine: 169
+    sourceFile: packages/cursor/src/path-policy.ts
+    sourceLine: 156
+  SYM-cursor-isKbFreshnessRelevantPath:
+    sourceColumn: 16
+    sourceEndColumn: 1
     sourceEndLine: 154
     sourceFile: packages/cursor/src/path-policy.ts
-    sourceLine: 141
+    sourceLine: 142
   SYM-cursor-isMeaningfulTrackedPath:
     sourceColumn: 16
     sourceEndColumn: 1
@@ -2045,9 +2063,9 @@ coordinates:
   SYM-cursor-loadHookState:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 196
+    sourceEndLine: 208
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 184
+    sourceLine: 196
   SYM-cursor-packageName:
     sourceColumn: 13
     sourceEndColumn: 40
@@ -2078,42 +2096,54 @@ coordinates:
     sourceEndLine: 104
     sourceFile: packages/cursor/src/hook-input.ts
     sourceLine: 96
+  SYM-cursor-recordKbMcpTool:
+    sourceColumn: 16
+    sourceEndColumn: 1
+    sourceEndLine: 327
+    sourceFile: packages/cursor/src/hook-state.ts
+    sourceLine: 302
   SYM-cursor-rememberGuidedPath:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 277
+    sourceEndLine: 289
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 254
+    sourceLine: 266
   SYM-cursor-resolveStateDir:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 182
+    sourceEndLine: 194
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 165
+    sourceLine: 177
   SYM-cursor-runHook:
     sourceColumn: 22
     sourceEndColumn: 1
-    sourceEndLine: 206
+    sourceEndLine: 220
     sourceFile: packages/cursor/src/hook-runner.ts
-    sourceLine: 86
+    sourceLine: 88
   SYM-cursor-saveHookState:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 211
+    sourceEndLine: 223
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 198
+    sourceLine: 210
+  SYM-cursor-stopFollowupMessage:
+    sourceColumn: 16
+    sourceEndColumn: 1
+    sourceEndLine: 25
+    sourceFile: packages/cursor/src/messages.ts
+    sourceLine: 11
   SYM-cursor-toRepoRelativePath:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 171
+    sourceEndLine: 186
     sourceFile: packages/cursor/src/path-policy.ts
-    sourceLine: 156
+    sourceLine: 171
   SYM-cursor-updateHookState:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 240
+    sourceEndLine: 252
     sourceFile: packages/cursor/src/hook-state.ts
-    sourceLine: 213
+    sourceLine: 225
   SYM-cursor-writeGuidance:
     sourceColumn: 16
     sourceEndColumn: 1
@@ -2606,6 +2636,30 @@ coordinates:
     sourceEndLine: 90
     sourceFile: packages/cli/src/extractors/markdown.ts
     sourceLine: 57
+  SYM-mcp-attachTestKb:
+    sourceColumn: 22
+    sourceEndColumn: 1
+    sourceEndLine: 49
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    sourceLine: 44
+  SYM-mcp-createIntegrationProlog:
+    sourceColumn: 16
+    sourceEndColumn: 1
+    sourceEndLine: 22
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    sourceLine: 16
+  SYM-mcp-createTestKbDir:
+    sourceColumn: 22
+    sourceEndColumn: 1
+    sourceEndLine: 42
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    sourceLine: 40
+  SYM-mcp-detachTestKb:
+    sourceColumn: 22
+    sourceEndColumn: 1
+    sourceEndLine: 55
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    sourceLine: 51
   SYM-mcp-session-activeBranchName:
     sourceColumn: 11
     sourceEndColumn: 39
@@ -2666,6 +2720,18 @@ coordinates:
     sourceEndLine: 104
     sourceFile: packages/mcp/src/server/session.ts
     sourceLine: 99
+  SYM-mcp-startIntegrationProlog:
+    sourceColumn: 22
+    sourceEndColumn: 1
+    sourceEndLine: 38
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    sourceLine: 24
+  SYM-mcp-stopIntegrationProlog:
+    sourceColumn: 22
+    sourceEndColumn: 1
+    sourceEndLine: 64
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    sourceLine: 57
   SYM-mergeCoordinatesWithManifest:
     sourceColumn: 16
     sourceEndColumn: 1

--- a/documentation/symbols.yaml
+++ b/documentation/symbols.yaml
@@ -18,6 +18,10 @@ symbols:
         target: REQ-009
       - type: covered_by
         target: TEST-001
+    sourceLine: 79
+    sourceColumn: 13
+    sourceEndLine: 662
+    sourceEndColumn: 1
   - id: SYM-PrologOptions
     title: PrologOptions
     sourceFile: packages/cli/src/prolog.ts
@@ -31,6 +35,10 @@ symbols:
         target: REQ-009
       - type: covered_by
         target: TEST-001
+    sourceLine: 68
+    sourceColumn: 17
+    sourceEndLine: 71
+    sourceEndColumn: 1
   - id: SYM-QueryResult
     title: QueryResult
     sourceFile: packages/cli/src/prolog.ts
@@ -44,6 +52,10 @@ symbols:
         target: REQ-009
       - type: covered_by
         target: TEST-001
+    sourceLine: 73
+    sourceColumn: 17
+    sourceEndLine: 77
+    sourceEndColumn: 1
   - id: SYM-resolveKbPlPath
     title: resolveKbPlPath
     sourceFile: packages/cli/src/prolog.ts
@@ -57,6 +69,10 @@ symbols:
         target: REQ-009
       - type: covered_by
         target: TEST-001
+    sourceLine: 29
+    sourceColumn: 16
+    sourceEndLine: 67
+    sourceEndColumn: 1
   - id: SYM-003
     title: handleKbQuery
     sourceFile: packages/mcp/src/tools/query.ts
@@ -67,6 +83,10 @@ symbols:
         target: REQ-mcp-tool-query
       - type: covered_by
         target: TEST-001
+    sourceLine: 48
+    sourceColumn: 22
+    sourceEndLine: 97
+    sourceEndColumn: 1
   - id: SYM-004
     title: handleKbCheck
     sourceFile: packages/mcp/src/tools/check.ts
@@ -80,6 +100,10 @@ symbols:
         target: REQ-core-validation-rules
       - type: covered_by
         target: TEST-001
+    sourceLine: 159
+    sourceColumn: 22
+    sourceEndLine: 219
+    sourceEndColumn: 1
   - id: SYM-010
     title: startServer
     sourceFile: packages/mcp/src/server.ts
@@ -90,6 +114,10 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-001
+    sourceLine: 37
+    sourceColumn: 22
+    sourceEndLine: 57
+    sourceEndColumn: 1
   - id: SYM-handleKbQueryRelationships
     title: handleKbQueryRelationships
     sourceFile: packages/mcp/src/tools/query-relationships.ts
@@ -110,6 +138,10 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
+    sourceLine: 73
+    sourceColumn: 16
+    sourceEndLine: 103
+    sourceEndColumn: 1
   - id: SYM-checkWorkspaceHealth
     title: checkWorkspaceHealth
     sourceFile: packages/opencode/src/workspace-health.ts
@@ -120,6 +152,10 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
+    sourceLine: 33
+    sourceColumn: 16
+    sourceEndLine: 96
+    sourceEndColumn: 1
   - id: SYM-detectPosture
     title: detectPosture
     sourceFile: packages/opencode/src/repo-posture.ts
@@ -130,6 +166,10 @@ symbols:
         target: REQ-opencode-posture-detection
       - type: covered_by
         target: TEST-opencode-smart-enforcement
+    sourceLine: 162
+    sourceColumn: 16
+    sourceEndLine: 241
+    sourceEndColumn: 1
   - id: SYM-classifyRisk
     title: classifyRisk
     sourceFile: packages/opencode/src/risk-classifier.ts
@@ -140,6 +180,10 @@ symbols:
         target: REQ-opencode-risk-classification
       - type: covered_by
         target: TEST-opencode-smart-enforcement
+    sourceLine: 63
+    sourceColumn: 16
+    sourceEndLine: 175
+    sourceEndColumn: 1
   - id: SYM-GuidanceCache
     title: GuidanceCache
     sourceFile: packages/opencode/src/guidance-cache.ts
@@ -150,6 +194,10 @@ symbols:
         target: REQ-opencode-guidance-caching
       - type: covered_by
         target: TEST-opencode-smart-enforcement
+    sourceLine: 46
+    sourceColumn: 13
+    sourceEndLine: 165
+    sourceEndColumn: 1
   - id: SYM-parseRdfRelationships
     title: parseRdfRelationships
     sourceFile: packages/vscode/src/shared/rdf-parser.ts
@@ -160,6 +208,10 @@ symbols:
         target: REQ-vscode-source-to-kb
       - type: covered_by
         target: TEST-vscode-traceability
+    sourceLine: 37
+    sourceColumn: 16
+    sourceEndLine: 67
+    sourceEndColumn: 1
   - id: SYM-KB_RELATIONSHIP_TYPES
     title: KB_RELATIONSHIP_TYPES
     sourceFile: packages/vscode/src/shared/rdf-parser.ts
@@ -170,6 +222,10 @@ symbols:
         target: REQ-vscode-source-to-kb
       - type: covered_by
         target: TEST-vscode-traceability
+    sourceLine: 15
+    sourceColumn: 13
+    sourceEndLine: 28
+    sourceEndColumn: 1
   - id: SYM-kb-status-json
     title: kb_status/0 (JSON)
     sourceFile: packages/core/src/status.pl
@@ -206,10 +262,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-001
-    sourceLine: 19
-    sourceColumn: 17
-    sourceEndLine: 43
-    sourceEndColumn: 1
   - id: SYM-cli-status-pre-first-sync-test
     title: cli status pre-sync test
     sourceFile: packages/cli/tests/commands/status.test.ts
@@ -240,10 +292,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 14
-    sourceColumn: 17
-    sourceEndLine: 19
-    sourceEndColumn: 1
   - id: SYM-AutoUpdateStatus
     title: AutoUpdateStatus
     sourceFile: packages/opencode/src/auto-update.ts
@@ -252,10 +300,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 21
-    sourceColumn: 12
-    sourceEndLine: 29
-    sourceEndColumn: 21
   - id: SYM-AutoUpdateResult
     title: AutoUpdateResult
     sourceFile: packages/opencode/src/auto-update.ts
@@ -264,10 +308,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 31
-    sourceColumn: 17
-    sourceEndLine: 35
-    sourceEndColumn: 1
   - id: SYM-AutoUpdateInput
     title: AutoUpdateInput
     sourceFile: packages/opencode/src/auto-update.ts
@@ -276,10 +316,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 37
-    sourceColumn: 17
-    sourceEndLine: 40
-    sourceEndColumn: 1
   - id: SYM-AutoUpdateRunnerDeps
     title: AutoUpdateRunnerDeps
     sourceFile: packages/opencode/src/auto-update.ts
@@ -288,10 +324,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 42
-    sourceColumn: 17
-    sourceEndLine: 49
-    sourceEndColumn: 1
   - id: SYM-findKibiOpencodePluginEntry
     title: findKibiOpencodePluginEntry
     sourceFile: packages/opencode/src/auto-update.ts
@@ -300,10 +332,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 99
-    sourceColumn: 16
-    sourceEndLine: 150
-    sourceEndColumn: 1
   - id: SYM-getCachedPluginVersion
     title: getCachedPluginVersion
     sourceFile: packages/opencode/src/auto-update.ts
@@ -312,10 +340,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 300
-    sourceColumn: 16
-    sourceEndLine: 333
-    sourceEndColumn: 1
   - id: SYM-getLatestPluginVersion
     title: getLatestPluginVersion
     sourceFile: packages/opencode/src/auto-update.ts
@@ -324,10 +348,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 335
-    sourceColumn: 22
-    sourceEndLine: 359
-    sourceEndColumn: 1
   - id: SYM-invalidateKibiOpencodePackage
     title: invalidateKibiOpencodePackage
     sourceFile: packages/opencode/src/auto-update.ts
@@ -336,10 +356,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 406
-    sourceColumn: 16
-    sourceEndLine: 426
-    sourceEndColumn: 1
   - id: SYM-runBunInstallForOpenCodePlugin
     title: runBunInstallForOpenCodePlugin
     sourceFile: packages/opencode/src/auto-update.ts
@@ -348,10 +364,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 449
-    sourceColumn: 16
-    sourceEndLine: 457
-    sourceEndColumn: 1
   - id: SYM-createAutoUpdateRunner
     title: createAutoUpdateRunner
     sourceFile: packages/opencode/src/auto-update.ts
@@ -360,10 +372,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 466
-    sourceColumn: 16
-    sourceEndLine: 533
-    sourceEndColumn: 1
   - id: SYM-runKibiOpencodeAutoUpdate
     title: runKibiOpencodeAutoUpdate
     sourceFile: packages/opencode/src/auto-update.ts
@@ -372,10 +380,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 535
-    sourceColumn: 13
-    sourceEndLine: 544
-    sourceEndColumn: 2
   - id: SYM-usage-metrics-command
     title: usageMetricsCommand
     sourceFile: packages/cli/src/commands/usage-metrics.ts
@@ -386,16 +390,16 @@ symbols:
         target: REQ-cli-usage-metrics-v1
       - type: covered_by
         target: TEST-cli-usage-metrics-v1
+    sourceLine: 82
+    sourceColumn: 22
+    sourceEndLine: 107
+    sourceEndColumn: 1
   - id: SYM-registerIndexCoverageTests
     title: registerIndexCoverageTests
     sourceFile: packages/opencode/tests/index.coverage.shared.ts
     relationships:
       - type: executable_for
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 7
-    sourceColumn: 16
-    sourceEndLine: 30
-    sourceEndColumn: 1
   - id: SYM-checkCommand
     title: checkCommand
     sourceFile: packages/cli/src/commands/check.ts
@@ -404,10 +408,6 @@ symbols:
         target: REQ-cli-check
       - type: covered_by
         target: TEST-004
-    sourceLine: 543
-    sourceColumn: 22
-    sourceEndLine: 891
-    sourceEndColumn: 1
   - id: SYM-CheckOptions
     title: CheckOptions
     sourceFile: packages/cli/src/commands/check.ts
@@ -416,10 +416,6 @@ symbols:
         target: REQ-cli-check
       - type: covered_by
         target: TEST-004
-    sourceLine: 93
-    sourceColumn: 17
-    sourceEndLine: 100
-    sourceEndColumn: 1
   - id: SYM-getCurrentBranch
     title: getCurrentBranch
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -428,10 +424,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 101
-    sourceColumn: 22
-    sourceEndLine: 112
-    sourceEndColumn: 1
   - id: SYM-createKbDirectoryStructure
     title: createKbDirectoryStructure
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -440,10 +432,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 114
-    sourceColumn: 16
-    sourceEndLine: 125
-    sourceEndColumn: 1
   - id: SYM-createConfigFile
     title: createConfigFile
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -452,10 +440,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 127
-    sourceColumn: 16
-    sourceEndLine: 133
-    sourceEndColumn: 1
   - id: SYM-updateGitIgnore
     title: updateGitIgnore
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -464,10 +448,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 135
-    sourceColumn: 16
-    sourceEndLine: 156
-    sourceEndColumn: 1
   - id: SYM-ensureSymbolsManifestFile
     title: ensureSymbolsManifestFile
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -476,10 +456,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 159
-    sourceColumn: 16
-    sourceEndLine: 170
-    sourceEndColumn: 1
   - id: SYM-copySchemaFiles
     title: copySchemaFiles
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -488,10 +464,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 172
-    sourceColumn: 22
-    sourceEndLine: 187
-    sourceEndColumn: 1
   - id: SYM-installHook
     title: installHook
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -500,10 +472,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 196
-    sourceColumn: 16
-    sourceEndLine: 230
-    sourceEndColumn: 1
   - id: SYM-installGitHooks
     title: installGitHooks
     sourceFile: packages/cli/src/commands/init-helpers.ts
@@ -512,10 +480,6 @@ symbols:
         target: REQ-cli-init
       - type: covered_by
         target: TEST-001
-    sourceLine: 232
-    sourceColumn: 16
-    sourceEndLine: 249
-    sourceEndColumn: 1
   - id: SYM-migrateCommand
     title: migrateCommand
     sourceFile: packages/cli/src/commands/migrate.ts
@@ -524,10 +488,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 407
-    sourceColumn: 22
-    sourceEndLine: 552
-    sourceEndColumn: 1
   - id: SYM-skillsListCommand
     title: skillsListCommand
     sourceFile: packages/cli/src/commands/skills.ts
@@ -536,10 +496,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 23
-    sourceColumn: 22
-    sourceEndLine: 35
-    sourceEndColumn: 1
   - id: SYM-skillsLoadCommand
     title: skillsLoadCommand
     sourceFile: packages/cli/src/commands/skills.ts
@@ -548,10 +504,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 37
-    sourceColumn: 22
-    sourceEndLine: 64
-    sourceEndColumn: 1
   - id: SYM-skillsReadCommand
     title: skillsReadCommand
     sourceFile: packages/cli/src/commands/skills.ts
@@ -560,10 +512,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 66
-    sourceColumn: 22
-    sourceEndLine: 80
-    sourceEndColumn: 1
   - id: SYM-skillsValidateCommand
     title: skillsValidateCommand
     sourceFile: packages/cli/src/commands/skills.ts
@@ -572,10 +520,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 82
-    sourceColumn: 22
-    sourceEndLine: 100
-    sourceEndColumn: 1
   - id: SYM-syncCommand
     title: syncCommand
     sourceFile: packages/cli/src/commands/sync.ts
@@ -584,10 +528,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 94
-    sourceColumn: 22
-    sourceEndLine: 540
-    sourceEndColumn: 1
   - id: SYM-SyncError
     title: SyncError
     sourceFile: packages/cli/src/commands/sync.ts
@@ -596,10 +536,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 65
-    sourceColumn: 13
-    sourceEndLine: 70
-    sourceEndColumn: 1
   - id: SYM-SyncResult
     title: SyncResult
     sourceFile: packages/cli/src/commands/sync.ts
@@ -608,10 +544,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 73
-    sourceColumn: 17
-    sourceEndLine: 75
-    sourceEndColumn: 1
   - id: SYM-refreshManifestCoordinates
     title: refreshManifestCoordinates
     sourceFile: packages/cli/src/commands/sync/manifest.ts
@@ -620,10 +552,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 83
-    sourceColumn: 22
-    sourceEndLine: 226
-    sourceEndColumn: 1
   - id: SYM-hasAllGeneratedCoordinates
     title: hasAllGeneratedCoordinates
     sourceFile: packages/cli/src/commands/sync/manifest.ts
@@ -632,10 +560,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 228
-    sourceColumn: 16
-    sourceEndLine: 238
-    sourceEndColumn: 1
   - id: SYM-isEligibleForCoordinateRefresh
     title: isEligibleForCoordinateRefresh
     sourceFile: packages/cli/src/commands/sync/manifest.ts
@@ -644,10 +568,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 240
-    sourceColumn: 16
-    sourceEndLine: 255
-    sourceEndColumn: 1
   - id: SYM-SYMBOLS-MANIFEST-COMMENT-BLOCK
     title: SYMBOLS_MANIFEST_COMMENT_BLOCK
     sourceFile: packages/cli/src/commands/sync/manifest.ts
@@ -656,10 +576,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 57
-    sourceColumn: 13
-    sourceEndLine: 63
-    sourceEndColumn: 1
   - id: SYM-createUniqueStagingPath
     title: createUniqueStagingPath
     sourceFile: packages/cli/src/commands/sync/staging.ts
@@ -668,10 +584,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 66
-    sourceColumn: 16
-    sourceEndLine: 78
-    sourceEndColumn: 1
   - id: SYM-cleanupAbandonedStagingDirectories
     title: cleanupAbandonedStagingDirectories
     sourceFile: packages/cli/src/commands/sync/staging.ts
@@ -680,10 +592,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 81
-    sourceColumn: 22
-    sourceEndLine: 137
-    sourceEndColumn: 1
   - id: SYM-prepareStagingEnvironment
     title: prepareStagingEnvironment
     sourceFile: packages/cli/src/commands/sync/staging.ts
@@ -692,10 +600,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 139
-    sourceColumn: 22
-    sourceEndLine: 158
-    sourceEndColumn: 1
   - id: SYM-atomicPublish
     title: atomicPublish
     sourceFile: packages/cli/src/commands/sync/staging.ts
@@ -704,10 +608,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 200
-    sourceColumn: 16
-    sourceEndLine: 220
-    sourceEndColumn: 1
   - id: SYM-cleanupStaging
     title: cleanupStaging
     sourceFile: packages/cli/src/commands/sync/staging.ts
@@ -716,10 +616,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 222
-    sourceColumn: 16
-    sourceEndLine: 231
-    sourceEndColumn: 1
   - id: SYM-extractFromManifestString
     title: extractFromManifestString
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -728,10 +624,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 349
-    sourceColumn: 16
-    sourceEndLine: 371
-    sourceEndColumn: 1
   - id: SYM-extractManifestSymbolRecordsString
     title: extractManifestSymbolRecordsString
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -740,10 +632,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 373
-    sourceColumn: 16
-    sourceEndLine: 395
-    sourceEndColumn: 1
   - id: SYM-extractFromManifest
     title: extractFromManifest
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -752,10 +640,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 397
-    sourceColumn: 16
-    sourceEndLine: 402
-    sourceEndColumn: 1
   - id: SYM-readManifestWithCoordinateOverlay
     title: readManifestWithCoordinateOverlay
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -764,10 +648,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 440
-    sourceColumn: 16
-    sourceEndLine: 454
-    sourceEndColumn: 1
   - id: SYM-ManifestError
     title: ManifestError
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -776,10 +656,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 189
-    sourceColumn: 13
-    sourceEndLine: 197
-    sourceEndColumn: 1
   - id: SYM-ExtractedEntity
     title: ExtractedEntity
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -788,10 +664,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 30
-    sourceColumn: 17
-    sourceEndLine: 44
-    sourceEndColumn: 1
   - id: SYM-ExtractedRelationship
     title: ExtractedRelationship
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -800,10 +672,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 46
-    sourceColumn: 17
-    sourceEndLine: 50
-    sourceEndColumn: 1
   - id: SYM-ExtractionResult
     title: ExtractionResult
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -812,10 +680,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 52
-    sourceColumn: 17
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-markdown-ExtractedEntity
     title: ExtractedEntity
     sourceFile: packages/cli/src/extractors/markdown.ts
@@ -824,10 +688,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 57
-    sourceColumn: 17
-    sourceEndLine: 90
-    sourceEndColumn: 1
   - id: SYM-ManifestSymbolRecord
     title: ManifestSymbolRecord
     sourceFile: packages/cli/src/extractors/manifest.ts
@@ -836,10 +696,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 199
-    sourceColumn: 17
-    sourceEndLine: 221
-    sourceEndColumn: 1
   - id: SYM-readCoordinateArtifact
     title: readCoordinateArtifact
     sourceFile: packages/cli/src/extractors/symbol-coordinates.ts
@@ -848,10 +704,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 79
-    sourceColumn: 16
-    sourceEndLine: 99
-    sourceEndColumn: 1
   - id: SYM-writeCoordinateArtifact
     title: writeCoordinateArtifact
     sourceFile: packages/cli/src/extractors/symbol-coordinates.ts
@@ -860,10 +712,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 102
-    sourceColumn: 16
-    sourceEndLine: 114
-    sourceEndColumn: 1
   - id: SYM-mergeCoordinatesWithManifest
     title: mergeCoordinatesWithManifest
     sourceFile: packages/cli/src/extractors/symbol-coordinates.ts
@@ -872,10 +720,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 117
-    sourceColumn: 16
-    sourceEndLine: 141
-    sourceEndColumn: 1
   - id: SYM-SymbolCoordinatesRecord
     title: SymbolCoordinatesRecord
     sourceFile: packages/cli/src/extractors/symbol-coordinates.ts
@@ -884,10 +728,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 4
-    sourceColumn: 17
-    sourceEndLine: 10
-    sourceEndColumn: 1
   - id: SYM-SymbolCoordinatesArtifact
     title: SymbolCoordinatesArtifact
     sourceFile: packages/cli/src/extractors/symbol-coordinates.ts
@@ -896,10 +736,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 12
-    sourceColumn: 17
-    sourceEndLine: 14
-    sourceEndColumn: 1
   - id: SYM-analyzeSourceText
     title: analyzeSourceText
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -908,10 +744,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 131
-    sourceColumn: 16
-    sourceEndLine: 161
-    sourceEndColumn: 1
   - id: SYM-enrichSymbolCoordinates
     title: enrichSymbolCoordinates
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -920,10 +752,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 163
-    sourceColumn: 22
-    sourceEndLine: 204
-    sourceEndColumn: 1
   - id: SYM-SourceSymbolAnalysis
     title: SourceSymbolAnalysis
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -932,10 +760,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 52
-    sourceColumn: 17
-    sourceEndLine: 60
-    sourceEndColumn: 1
   - id: SYM-SourceModuleAnalysis
     title: SourceModuleAnalysis
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -944,10 +768,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 62
-    sourceColumn: 17
-    sourceEndLine: 67
-    sourceEndColumn: 1
   - id: SYM-SourceAnalysisResult
     title: SourceAnalysisResult
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -956,10 +776,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 69
-    sourceColumn: 17
-    sourceEndLine: 75
-    sourceEndColumn: 1
   - id: SYM-SourceAnalysisProvider
     title: SourceAnalysisProvider
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -968,10 +784,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 77
-    sourceColumn: 17
-    sourceEndLine: 81
-    sourceEndColumn: 1
   - id: SYM-AnalyzeSourceTextOptions
     title: AnalyzeSourceTextOptions
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -980,10 +792,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 83
-    sourceColumn: 17
-    sourceEndLine: 85
-    sourceEndColumn: 1
   - id: SYM-SourceAnalysisMode
     title: SourceAnalysisMode
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -992,10 +800,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 40
-    sourceColumn: 12
-    sourceEndLine: 40
-    sourceEndColumn: 55
   - id: SYM-SourceSymbolKind
     title: SourceSymbolKind
     sourceFile: packages/cli/src/extractors/symbols-coordinator.ts
@@ -1009,10 +813,6 @@ symbols:
         target: REQ-symbol-granularity
       - type: covered_by
         target: TEST-007
-    sourceLine: 42
-    sourceColumn: 12
-    sourceEndLine: 50
-    sourceEndColumn: 14
   - id: SYM-createTsMorphSourceAnalysisProvider
     title: createTsMorphSourceAnalysisProvider
     sourceFile: packages/cli/src/extractors/symbols-ts.ts
@@ -1021,10 +821,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 68
-    sourceColumn: 16
-    sourceEndLine: 99
-    sourceEndColumn: 1
   - id: SYM-enrichSymbolCoordinatesWithTsMorph
     title: enrichSymbolCoordinatesWithTsMorph
     sourceFile: packages/cli/src/extractors/symbols-ts.ts
@@ -1033,10 +829,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 101
-    sourceColumn: 22
-    sourceEndLine: 175
-    sourceEndColumn: 1
   - id: SYM-SymbolCoordinates
     title: SymbolCoordinates
     sourceFile: packages/cli/src/extractors/symbols-ts.ts
@@ -1045,10 +837,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 35
-    sourceColumn: 17
-    sourceEndLine: 41
-    sourceEndColumn: 1
   - id: SYM-ManifestSymbolEntry
     title: ManifestSymbolEntry
     sourceFile: packages/cli/src/extractors/symbols-ts.ts
@@ -1057,10 +845,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 43
-    sourceColumn: 17
-    sourceEndLine: 54
-    sourceEndColumn: 1
   - id: SYM-createRepoIgnorePolicy
     title: createRepoIgnorePolicy
     sourceFile: packages/cli/src/public/ignore-policy.ts
@@ -1069,10 +853,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-008
-    sourceLine: 45
-    sourceColumn: 16
-    sourceEndLine: 245
-    sourceEndColumn: 1
   - id: SYM-IgnorePolicy
     title: IgnorePolicy
     sourceFile: packages/cli/src/public/ignore-policy.ts
@@ -1081,10 +861,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-008
-    sourceLine: 21
-    sourceColumn: 17
-    sourceEndLine: 25
-    sourceEndColumn: 1
   - id: SYM-isOperationalArtifactPath
     title: isOperationalArtifactPath
     sourceFile: packages/cli/src/public/operational-artifacts.ts
@@ -1093,10 +869,6 @@ symbols:
         target: REQ-core-extractors
       - type: covered_by
         target: TEST-007
-    sourceLine: 1
-    sourceColumn: 16
-    sourceEndLine: 6
-    sourceEndColumn: 1
   - id: SYM-setBundledSkillsDir
     title: setBundledSkillsDir
     sourceFile: packages/cli/src/public/skills.ts
@@ -1105,10 +877,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 27
-    sourceColumn: 16
-    sourceEndLine: 29
-    sourceEndColumn: 1
   - id: SYM-resetBundledSkillsDir
     title: resetBundledSkillsDir
     sourceFile: packages/cli/src/public/skills.ts
@@ -1117,10 +885,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 31
-    sourceColumn: 16
-    sourceEndLine: 33
-    sourceEndColumn: 1
   - id: SYM-listBundledSkills
     title: listBundledSkills
     sourceFile: packages/cli/src/public/skills.ts
@@ -1129,10 +893,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 96
-    sourceColumn: 16
-    sourceEndLine: 108
-    sourceEndColumn: 1
   - id: SYM-loadBundledSkill
     title: loadBundledSkill
     sourceFile: packages/cli/src/public/skills.ts
@@ -1141,10 +901,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 110
-    sourceColumn: 16
-    sourceEndLine: 118
-    sourceEndColumn: 1
   - id: SYM-readBundledSkillResource
     title: readBundledSkillResource
     sourceFile: packages/cli/src/public/skills.ts
@@ -1153,10 +909,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 120
-    sourceColumn: 16
-    sourceEndLine: 152
-    sourceEndColumn: 1
   - id: SYM-validateSkillBundle
     title: validateSkillBundle
     sourceFile: packages/cli/src/public/skills.ts
@@ -1165,10 +917,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 154
-    sourceColumn: 16
-    sourceEndLine: 177
-    sourceEndColumn: 1
   - id: SYM-SkillNotFoundError
     title: SkillNotFoundError
     sourceFile: packages/cli/src/public/skills.ts
@@ -1177,10 +925,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 51
-    sourceColumn: 13
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-SkillResourceNotFoundError
     title: SkillResourceNotFoundError
     sourceFile: packages/cli/src/public/skills.ts
@@ -1189,10 +933,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 58
-    sourceColumn: 13
-    sourceEndLine: 63
-    sourceEndColumn: 1
   - id: SYM-SkillResourceOutOfBoundsError
     title: SkillResourceOutOfBoundsError
     sourceFile: packages/cli/src/public/skills.ts
@@ -1201,10 +941,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 65
-    sourceColumn: 13
-    sourceEndLine: 70
-    sourceEndColumn: 1
   - id: SYM-SkillValidationError
     title: SkillValidationError
     sourceFile: packages/cli/src/public/skills.ts
@@ -1213,10 +949,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 72
-    sourceColumn: 13
-    sourceEndLine: 80
-    sourceEndColumn: 1
   - id: SYM-SkillOversizeError
     title: SkillOversizeError
     sourceFile: packages/cli/src/public/skills.ts
@@ -1225,10 +957,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 82
-    sourceColumn: 13
-    sourceEndLine: 94
-    sourceEndColumn: 1
   - id: SYM-SkillManifest
     title: SkillManifest
     sourceFile: packages/cli/src/public/skills.ts
@@ -1237,10 +965,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 35
-    sourceColumn: 17
-    sourceEndLine: 43
-    sourceEndColumn: 1
   - id: SYM-SkillBundle
     title: SkillBundle
     sourceFile: packages/cli/src/public/skills.ts
@@ -1249,10 +973,6 @@ symbols:
         target: REQ-reusable-skill-subsystem
       - type: covered_by
         target: TEST-skill-cli-load-validate
-    sourceLine: 45
-    sourceColumn: 17
-    sourceEndLine: 49
-    sourceEndColumn: 1
   - id: SYM-rankEntities
     title: rankEntities
     sourceFile: packages/cli/src/search-ranking.ts
@@ -1261,10 +981,6 @@ symbols:
         target: REQ-mcp-search-discovery
       - type: covered_by
         target: TEST-mcp-search-discovery
-    sourceLine: 57
-    sourceColumn: 22
-    sourceEndLine: 91
-    sourceEndColumn: 1
   - id: SYM-loadMarkdownBody
     title: loadMarkdownBody
     sourceFile: packages/cli/src/search-ranking.ts
@@ -1273,10 +989,6 @@ symbols:
         target: REQ-mcp-search-discovery
       - type: covered_by
         target: TEST-mcp-search-discovery
-    sourceLine: 193
-    sourceColumn: 22
-    sourceEndLine: 226
-    sourceEndColumn: 1
   - id: SYM-SearchMatch
     title: SearchMatch
     sourceFile: packages/cli/src/search-ranking.ts
@@ -1285,10 +997,6 @@ symbols:
         target: REQ-mcp-search-discovery
       - type: covered_by
         target: TEST-mcp-search-discovery
-    sourceLine: 4
-    sourceColumn: 17
-    sourceEndLine: 9
-    sourceEndColumn: 1
   - id: SYM-getBehaviorSourcePaths
     title: getBehaviorSourcePaths
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1297,10 +1005,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 162
-    sourceColumn: 16
-    sourceEndLine: 167
-    sourceEndColumn: 1
   - id: SYM-getKbCoveredSourcePaths
     title: getKbCoveredSourcePaths
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1309,10 +1013,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 170
-    sourceColumn: 16
-    sourceEndLine: 180
-    sourceEndColumn: 1
   - id: SYM-getFreshSymbolsManifestSourcePaths
     title: getFreshSymbolsManifestSourcePaths
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1321,10 +1021,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 183
-    sourceColumn: 16
-    sourceEndLine: 191
-    sourceEndColumn: 1
   - id: SYM-getKbEvidencePaths
     title: getKbEvidencePaths
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1333,10 +1029,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 197
-    sourceColumn: 16
-    sourceEndLine: 209
-    sourceEndColumn: 1
   - id: SYM-hasOverrideRationale
     title: hasOverrideRationale
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1345,10 +1037,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 212
-    sourceColumn: 16
-    sourceEndLine: 217
-    sourceEndColumn: 1
   - id: SYM-getMissingBehaviorSourcePaths
     title: getMissingBehaviorSourcePaths
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1357,10 +1045,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 223
-    sourceColumn: 16
-    sourceEndLine: 233
-    sourceEndColumn: 1
   - id: SYM-KibiImpactSourceChange
     title: KibiImpactSourceChange
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1369,10 +1053,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 46
-    sourceColumn: 17
-    sourceEndLine: 51
-    sourceEndColumn: 1
   - id: SYM-KibiImpactKbArtifact
     title: KibiImpactKbArtifact
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1381,10 +1061,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 59
-    sourceColumn: 17
-    sourceEndLine: 70
-    sourceEndColumn: 1
   - id: SYM-KibiImpactSymbolsManifest
     title: KibiImpactSymbolsManifest
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1393,10 +1069,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 82
-    sourceColumn: 17
-    sourceEndLine: 89
-    sourceEndColumn: 1
   - id: SYM-KibiNoImpactOverride
     title: KibiNoImpactOverride
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1405,10 +1077,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 102
-    sourceColumn: 17
-    sourceEndLine: 113
-    sourceEndColumn: 1
   - id: SYM-KibiImpactKbChangesMode
     title: KibiImpactKbChangesMode
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1417,10 +1085,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 116
-    sourceColumn: 17
-    sourceEndLine: 120
-    sourceEndColumn: 1
   - id: SYM-KibiImpactNoImpactOverrideMode
     title: KibiImpactNoImpactOverrideMode
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1429,10 +1093,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 123
-    sourceColumn: 17
-    sourceEndLine: 127
-    sourceEndColumn: 1
   - id: SYM-KibiImpactMissingMode
     title: KibiImpactMissingMode
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1441,10 +1101,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 130
-    sourceColumn: 17
-    sourceEndLine: 132
-    sourceEndColumn: 1
   - id: SYM-KibiImpactEvidence
     title: KibiImpactEvidence
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1453,10 +1109,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 148
-    sourceColumn: 17
-    sourceEndLine: 155
-    sourceEndColumn: 1
   - id: SYM-KibiEntityType
     title: KibiEntityType
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1465,10 +1117,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 23
-    sourceColumn: 12
-    sourceEndLine: 31
-    sourceEndColumn: 11
   - id: SYM-SourceChangeKind
     title: SourceChangeKind
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1477,10 +1125,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 41
-    sourceColumn: 12
-    sourceEndLine: 43
-    sourceEndColumn: 31
   - id: SYM-KibiNoImpactReason
     title: KibiNoImpactReason
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1489,10 +1133,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 92
-    sourceColumn: 12
-    sourceEndLine: 94
-    sourceEndColumn: 33
   - id: SYM-KibiImpactMode
     title: KibiImpactMode
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1501,10 +1141,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 135
-    sourceColumn: 12
-    sourceEndLine: 138
-    sourceEndColumn: 26
   - id: SYM-KIBI-ENTITY-SCHEMA-DOC
     title: KIBI_ENTITY_SCHEMA_DOC
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1513,10 +1149,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 10
-    sourceColumn: 13
-    sourceEndLine: 10
-    sourceEndColumn: 61
   - id: SYM-KIBI-SYMBOLS-MANIFEST-PATH
     title: KIBI_SYMBOLS_MANIFEST_PATH
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1525,10 +1157,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 13
-    sourceColumn: 13
-    sourceEndLine: 13
-    sourceEndColumn: 70
   - id: SYM-KIBI-SYMBOL-COORDINATES-PATH
     title: KIBI_SYMBOL_COORDINATES_PATH
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1537,10 +1165,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 16
-    sourceColumn: 13
-    sourceEndLine: 17
-    sourceEndColumn: 41
   - id: SYM-KIBI-NO-IMPACT-DECLARATION
     title: KIBI_NO_IMPACT_DECLARATION
     sourceFile: packages/cli/src/traceability/evidence-model.ts
@@ -1549,10 +1173,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 20
-    sourceColumn: 13
-    sourceEndLine: 20
-    sourceEndColumn: 61
   - id: SYM-collectStagedKibiDiagnostics
     title: collectStagedKibiDiagnostics
     sourceFile: packages/cli/src/traceability/staged-diagnostics.ts
@@ -1561,10 +1181,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 91
-    sourceColumn: 16
-    sourceEndLine: 129
-    sourceEndColumn: 1
   - id: SYM-KibiImpactDiagnostic
     title: KibiImpactDiagnostic
     sourceFile: packages/cli/src/traceability/staged-diagnostics.ts
@@ -1573,10 +1189,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 17
-    sourceColumn: 17
-    sourceEndLine: 30
-    sourceEndColumn: 1
   - id: SYM-KibiImpactDiagnosticId
     title: KibiImpactDiagnosticId
     sourceFile: packages/cli/src/traceability/staged-diagnostics.ts
@@ -1585,10 +1197,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 11
-    sourceColumn: 12
-    sourceEndLine: 15
-    sourceEndColumn: 45
   - id: SYM-assessStagedSymbolsManifest
     title: assessStagedSymbolsManifest
     sourceFile: packages/cli/src/traceability/staged-symbols-manifest.ts
@@ -1597,10 +1205,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 323
-    sourceColumn: 16
-    sourceEndLine: 405
-    sourceEndColumn: 1
   - id: SYM-collectStagedAuthoredSymbolsManifestEvidence
     title: collectStagedAuthoredSymbolsManifestEvidence
     sourceFile: packages/cli/src/traceability/staged-symbols-manifest.ts
@@ -1609,10 +1213,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 425
-    sourceColumn: 16
-    sourceEndLine: 479
-    sourceEndColumn: 1
   - id: SYM-StagedSymbolsManifestAssessment
     title: StagedSymbolsManifestAssessment
     sourceFile: packages/cli/src/traceability/staged-symbols-manifest.ts
@@ -1621,10 +1221,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 44
-    sourceColumn: 17
-    sourceEndLine: 48
-    sourceEndColumn: 1
   - id: SYM-StagedAuthoredSymbolsManifestEvidence
     title: StagedAuthoredSymbolsManifestEvidence
     sourceFile: packages/cli/src/traceability/staged-symbols-manifest.ts
@@ -1633,10 +1229,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 50
-    sourceColumn: 17
-    sourceEndLine: 53
-    sourceEndColumn: 1
   - id: SYM-createManifestLookupSentinelKey
     title: createManifestLookupSentinelKey
     sourceFile: packages/cli/src/traceability/symbol-extract.ts
@@ -1645,10 +1237,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 43
-    sourceColumn: 16
-    sourceEndLine: 46
-    sourceEndColumn: 1
   - id: SYM-extractSymbolsFromStagedFile
     title: extractSymbolsFromStagedFile
     sourceFile: packages/cli/src/traceability/symbol-extract.ts
@@ -1664,10 +1252,6 @@ symbols:
         target: TEST-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-symbol-extract-methods
-    sourceLine: 273
-    sourceColumn: 16
-    sourceEndLine: 510
-    sourceEndColumn: 1
   - id: SYM-ExtractedSymbol
     title: ExtractedSymbol
     sourceFile: packages/cli/src/traceability/symbol-extract.ts
@@ -1683,10 +1267,6 @@ symbols:
         target: TEST-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-symbol-extract-methods
-    sourceLine: 21
-    sourceColumn: 17
-    sourceEndLine: 34
-    sourceEndColumn: 1
   - id: SYM-ManifestLookupEntry
     title: ManifestLookupEntry
     sourceFile: packages/cli/src/traceability/symbol-extract.ts
@@ -1695,10 +1275,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 36
-    sourceColumn: 17
-    sourceEndLine: 39
-    sourceEndColumn: 1
   - id: SYM-ManifestLookup
     title: ManifestLookup
     sourceFile: packages/cli/src/traceability/symbol-extract.ts
@@ -1707,10 +1283,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 41
-    sourceColumn: 12
-    sourceEndLine: 41
-    sourceEndColumn: 62
   - id: SYM-resetModuleState
     title: resetModuleState
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1719,10 +1291,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 30
-    sourceColumn: 16
-    sourceEndLine: 39
-    sourceEndColumn: 1
   - id: SYM-setPrologFactory
     title: _setPrologFactory
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1731,10 +1299,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 50
-    sourceColumn: 16
-    sourceEndLine: 55
-    sourceEndColumn: 1
   - id: SYM-consultOverlay
     title: consultOverlay
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1744,10 +1308,6 @@ symbols:
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
     granularity_reason: legacy-link
-    sourceLine: 195
-    sourceColumn: 15
-    sourceEndLine: 211
-    sourceEndColumn: 1
   - id: SYM-projectStagedEntities
     title: projectStagedEntities
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1756,10 +1316,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 216
-    sourceColumn: 22
-    sourceEndLine: 248
-    sourceEndColumn: 1
   - id: SYM-createTempKb
     title: createTempKb
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1768,10 +1324,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 250
-    sourceColumn: 22
-    sourceEndLine: 295
-    sourceEndColumn: 1
   - id: SYM-createOverlayFacts
     title: createOverlayFacts
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1780,10 +1332,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 298
-    sourceColumn: 16
-    sourceEndLine: 316
-    sourceEndColumn: 1
   - id: SYM-cleanupTempKb
     title: cleanupTempKb
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1792,10 +1340,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 318
-    sourceColumn: 22
-    sourceEndLine: 345
-    sourceEndColumn: 1
   - id: SYM-TempKbContext
     title: TempKbContext
     sourceFile: packages/cli/src/traceability/temp-kb.ts
@@ -1804,10 +1348,6 @@ symbols:
         target: REQ-cli-staged-impact-enforcement
       - type: covered_by
         target: TEST-cli-staged-impact-enforcement
-    sourceLine: 15
-    sourceColumn: 17
-    sourceEndLine: 20
-    sourceEndColumn: 1
   - id: SYM-loadConfig
     title: loadConfig
     sourceFile: packages/cli/src/utils/config.ts
@@ -1816,10 +1356,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 130
-    sourceColumn: 16
-    sourceEndLine: 165
-    sourceEndColumn: 1
   - id: SYM-loadSyncConfig
     title: loadSyncConfig
     sourceFile: packages/cli/src/utils/config.ts
@@ -1828,10 +1364,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 175
-    sourceColumn: 16
-    sourceEndLine: 210
-    sourceEndColumn: 1
   - id: SYM-KbConfigPaths
     title: KbConfigPaths
     sourceFile: packages/cli/src/utils/config.ts
@@ -1840,10 +1372,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 31
-    sourceColumn: 17
-    sourceEndLine: 40
-    sourceEndColumn: 1
   - id: SYM-KbConfig
     title: KbConfig
     sourceFile: packages/cli/src/utils/config.ts
@@ -1852,10 +1380,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 46
-    sourceColumn: 17
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-DEFAULT-CONFIG
     title: DEFAULT_CONFIG
     sourceFile: packages/cli/src/utils/config.ts
@@ -1864,10 +1388,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 64
-    sourceColumn: 13
-    sourceEndLine: 80
-    sourceEndColumn: 1
   - id: SYM-DEFAULT-SYNC-PATHS
     title: DEFAULT_SYNC_PATHS
     sourceFile: packages/cli/src/utils/config.ts
@@ -1876,10 +1396,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 85
-    sourceColumn: 13
-    sourceEndLine: 95
-    sourceEndColumn: 1
   - id: SYM-resolveSymbolsManifestPaths
     title: resolveSymbolsManifestPaths
     sourceFile: packages/cli/src/utils/manifest-paths.ts
@@ -1888,10 +1404,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-001
-    sourceLine: 87
-    sourceColumn: 16
-    sourceEndLine: 99
-    sourceEndColumn: 1
   - id: SYM-resolveSymbolsManifestPath
     title: resolveSymbolsManifestPath
     sourceFile: packages/cli/src/utils/manifest-paths.ts
@@ -1900,10 +1412,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-001
-    sourceLine: 102
-    sourceColumn: 16
-    sourceEndLine: 107
-    sourceEndColumn: 1
   - id: SYM-DEFAULT-SYMBOLS-PATH
     title: DEFAULT_SYMBOLS_PATH
     sourceFile: packages/cli/src/utils/manifest-paths.ts
@@ -1912,10 +1420,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-001
-    sourceLine: 4
-    sourceColumn: 13
-    sourceEndLine: 4
-    sourceEndColumn: 64
   - id: SYM-DEFAULT-COORDINATES-PATH
     title: DEFAULT_COORDINATES_PATH
     sourceFile: packages/cli/src/utils/manifest-paths.ts
@@ -1924,10 +1428,6 @@ symbols:
         target: REQ-001
       - type: covered_by
         target: TEST-001
-    sourceLine: 5
-    sourceColumn: 13
-    sourceEndLine: 5
-    sourceEndColumn: 79
   - id: SYM-normalizeSchemaVersion
     title: normalizeSchemaVersion
     sourceFile: packages/cli/src/utils/schema-version.ts
@@ -1936,10 +1436,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 17
-    sourceColumn: 16
-    sourceEndLine: 35
-    sourceEndColumn: 1
   - id: SYM-getSchemaVersionStatus
     title: getSchemaVersionStatus
     sourceFile: packages/cli/src/utils/schema-version.ts
@@ -1948,10 +1444,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 38
-    sourceColumn: 16
-    sourceEndLine: 85
-    sourceEndColumn: 1
   - id: SYM-SchemaVersionStatus
     title: SchemaVersionStatus
     sourceFile: packages/cli/src/utils/schema-version.ts
@@ -1960,10 +1452,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 6
-    sourceColumn: 17
-    sourceEndLine: 12
-    sourceEndColumn: 1
   - id: SYM-LATEST-KB-SCHEMA-VERSION
     title: LATEST_KB_SCHEMA_VERSION
     sourceFile: packages/cli/src/utils/schema-version.ts
@@ -1972,10 +1460,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-config-schema
-    sourceLine: 4
-    sourceColumn: 13
-    sourceEndLine: 4
-    sourceEndColumn: 41
   - id: SYM-normalizeSubjectKey
     title: normalizeSubjectKey
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -1984,10 +1468,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 96
-    sourceColumn: 16
-    sourceEndLine: 113
-    sourceEndColumn: 1
   - id: SYM-normalizePropertyKey
     title: normalizePropertyKey
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -1996,10 +1476,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 115
-    sourceColumn: 16
-    sourceEndLine: 130
-    sourceEndColumn: 1
   - id: SYM-buildStableRequirementIds
     title: buildStableRequirementIds
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2008,10 +1484,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 132
-    sourceColumn: 16
-    sourceEndLine: 158
-    sourceEndColumn: 1
   - id: SYM-buildStrictWriteSet
     title: buildStrictWriteSet
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2020,10 +1492,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 160
-    sourceColumn: 16
-    sourceEndLine: 278
-    sourceEndColumn: 1
   - id: SYM-modelRequirementClaims
     title: modelRequirementClaims
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2032,10 +1500,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 280
-    sourceColumn: 16
-    sourceEndLine: 300
-    sourceEndColumn: 1
   - id: SYM-SemanticClaim
     title: SemanticClaim
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2044,10 +1508,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 27
-    sourceColumn: 17
-    sourceEndLine: 35
-    sourceEndColumn: 1
   - id: SYM-StrictModelInput
     title: StrictModelInput
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2056,10 +1516,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 37
-    sourceColumn: 17
-    sourceEndLine: 41
-    sourceEndColumn: 1
   - id: SYM-EntitySpec
     title: EntitySpec
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2068,10 +1524,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 52
-    sourceColumn: 17
-    sourceEndLine: 59
-    sourceEndColumn: 1
   - id: SYM-StableRequirementIds
     title: StableRequirementIds
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2080,10 +1532,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 66
-    sourceColumn: 17
-    sourceEndLine: 76
-    sourceEndColumn: 1
   - id: SYM-RelationshipSpec
     title: RelationshipSpec
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2092,10 +1540,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 61
-    sourceColumn: 12
-    sourceEndLine: 64
-    sourceEndColumn: 2
   - id: SYM-StrictWriteSet
     title: StrictWriteSet
     sourceFile: packages/cli/src/utils/strict-modeling.ts
@@ -2104,10 +1548,6 @@ symbols:
         target: REQ-011
       - type: covered_by
         target: TEST-cli-strict-modeling
-    sourceLine: 94
-    sourceColumn: 12
-    sourceEndLine: 94
-    sourceEndColumn: 77
   - id: SYM-setupDocsAndPrompts
     title: setupDocsAndPrompts
     sourceFile: packages/mcp/src/server/docs.ts
@@ -2126,10 +1566,6 @@ symbols:
         target: TEST-005
       - type: covered_by
         target: TEST-mcp-suggest-predicates
-    sourceLine: 296
-    sourceColumn: 16
-    sourceEndLine: 324
-    sourceEndColumn: 1
   - id: SYM-DocResource
     title: DocResource
     sourceFile: packages/mcp/src/server/docs.ts
@@ -2140,10 +1576,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 32
-    sourceColumn: 17
-    sourceEndLine: 38
-    sourceEndColumn: 1
   - id: SYM-PROMPTS
     title: PROMPTS
     sourceFile: packages/mcp/src/server/docs.ts
@@ -2164,10 +1596,6 @@ symbols:
         target: TEST-mcp-suggest-predicates
       - type: covered_by
         target: TEST-mcp-upsert-coverage
-    sourceLine: 71
-    sourceColumn: 13
-    sourceEndLine: 196
-    sourceEndColumn: 1
   - id: SYM-DOC-RESOURCES
     title: DOC_RESOURCES
     sourceFile: packages/mcp/src/server/docs.ts
@@ -2183,10 +1611,6 @@ symbols:
         target: TEST-005
       - type: covered_by
         target: TEST-mcp-suggest-predicates
-    sourceLine: 294
-    sourceColumn: 13
-    sourceEndLine: 294
-    sourceEndColumn: 51
   - id: SYM-setToolsServerDepsForTests
     title: _setToolsServerDepsForTests
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2195,10 +1619,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 97
-    sourceColumn: 16
-    sourceEndLine: 106
-    sourceEndColumn: 1
   - id: SYM-resetSessionModulePromise
     title: _resetSessionModulePromise
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2207,10 +1627,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 109
-    sourceColumn: 16
-    sourceEndLine: 111
-    sourceEndColumn: 1
   - id: SYM-mcp-session-prologProcess
     title: prologProcess
     sourceFile: packages/mcp/src/server/session.ts
@@ -2219,10 +1635,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 65
-    sourceColumn: 11
-    sourceEndLine: 65
-    sourceEndColumn: 53
   - id: SYM-mcp-session-activeBranchName
     title: activeBranchName
     sourceFile: packages/mcp/src/server/session.ts
@@ -2231,10 +1643,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 67
-    sourceColumn: 11
-    sourceEndLine: 67
-    sourceEndColumn: 39
   - id: SYM-mcp-session-isShuttingDown
     title: isShuttingDown
     sourceFile: packages/mcp/src/server/session.ts
@@ -2243,10 +1651,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 78
-    sourceColumn: 11
-    sourceEndLine: 78
-    sourceEndColumn: 33
   - id: SYM-mcp-session-inFlightRequests
     title: inFlightRequests
     sourceFile: packages/mcp/src/server/session.ts
@@ -2255,10 +1659,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 80
-    sourceColumn: 13
-    sourceEndLine: 80
-    sourceEndColumn: 67
   - id: SYM-mcp-session-resetSessionStateForTests
     title: resetSessionStateForTests
     sourceFile: packages/mcp/src/server/session.ts
@@ -2267,10 +1667,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 83
-    sourceColumn: 16
-    sourceEndLine: 97
-    sourceEndColumn: 1
   - id: SYM-mcp-session-setSessionDepsForTests
     title: _setSessionDepsForTests
     sourceFile: packages/mcp/src/server/session.ts
@@ -2279,10 +1675,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 99
-    sourceColumn: 16
-    sourceEndLine: 104
-    sourceEndColumn: 1
   - id: SYM-mcp-session-resetSessionDepsForTests
     title: _resetSessionDepsForTests
     sourceFile: packages/mcp/src/server/session.ts
@@ -2291,10 +1683,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 106
-    sourceColumn: 16
-    sourceEndLine: 109
-    sourceEndColumn: 1
   - id: SYM-mcp-session-ensureBranchKbExists
     title: ensureBranchKbExists
     sourceFile: packages/mcp/src/server/session.ts
@@ -2303,10 +1691,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 117
-    sourceColumn: 16
-    sourceEndLine: 154
-    sourceEndColumn: 1
   - id: SYM-mcp-session-initiateGracefulShutdown
     title: initiateGracefulShutdown
     sourceFile: packages/mcp/src/server/session.ts
@@ -2315,10 +1699,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 156
-    sourceColumn: 22
-    sourceEndLine: 205
-    sourceEndColumn: 1
   - id: SYM-resetProlog
     title: resetProlog
     sourceFile: packages/mcp/src/server/session.ts
@@ -2327,6 +1707,10 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
+    sourceLine: 208
+    sourceColumn: 22
+    sourceEndLine: 225
+    sourceEndColumn: 1
   - id: SYM-mcp-session-ensureProlog
     title: ensureProlog
     sourceFile: packages/mcp/src/server/session.ts
@@ -2335,10 +1719,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 495
-    sourceColumn: 22
-    sourceEndLine: 508
-    sourceEndColumn: 1
   - id: SYM-DIAGNOSTIC_MODE_ENABLED
     title: DIAGNOSTIC_MODE_ENABLED
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2347,10 +1727,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 29
-    sourceColumn: 13
-    sourceEndLine: 30
-    sourceEndColumn: 45
   - id: SYM-initializeDiagnosticMode
     title: initializeDiagnosticMode
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2359,10 +1735,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 43
-    sourceColumn: 16
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-appendUsageLogLine
     title: appendUsageLogLine
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2371,10 +1743,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 63
-    sourceColumn: 16
-    sourceEndLine: 72
-    sourceEndColumn: 1
   - id: SYM-DIAGNOSTIC_TELEMETRY_SCHEMA
     title: DIAGNOSTIC_TELEMETRY_SCHEMA
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2383,10 +1751,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 77
-    sourceColumn: 13
-    sourceEndLine: 108
-    sourceEndColumn: 1
   - id: SYM-ToolCallPayload
     title: ToolCallPayload
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2395,10 +1759,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 113
-    sourceColumn: 17
-    sourceEndLine: 116
-    sourceEndColumn: 1
   - id: SYM-DiagnosticErrorFields
     title: DiagnosticErrorFields
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2407,10 +1767,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 118
-    sourceColumn: 17
-    sourceEndLine: 124
-    sourceEndColumn: 1
   - id: SYM-classifyDiagnosticError
     title: classifyDiagnosticError
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2421,10 +1777,6 @@ symbols:
         target: REQ-008
       - type: covered_by
         target: TEST-005
-    sourceLine: 127
-    sourceColumn: 16
-    sourceEndLine: 245
-    sourceEndColumn: 1
   - id: SYM-deriveDiagnosticFields
     title: deriveDiagnosticFields
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2433,10 +1785,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 263
-    sourceColumn: 16
-    sourceEndLine: 306
-    sourceEndColumn: 1
   - id: SYM-extractToolCallPayload
     title: extractToolCallPayload
     sourceFile: packages/mcp/src/diagnostics.ts
@@ -2445,10 +1793,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 311
-    sourceColumn: 16
-    sourceEndLine: 320
-    sourceEndColumn: 1
   - id: SYM-jsonSchemaToZod
     title: jsonSchemaToZod
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2457,10 +1801,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 252
-    sourceColumn: 16
-    sourceEndLine: 381
-    sourceEndColumn: 1
   - id: SYM-addTool
     title: addTool
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2469,10 +1809,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 384
-    sourceColumn: 16
-    sourceEndLine: 532
-    sourceEndColumn: 1
   - id: SYM-registerAllTools
     title: registerAllTools
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2488,10 +1824,6 @@ symbols:
         target: TEST-005
       - type: covered_by
         target: TEST-mcp-suggest-predicates
-    sourceLine: 535
-    sourceColumn: 16
-    sourceEndLine: 766
-    sourceEndColumn: 1
   - id: SYM-ToolConfig
     title: ToolConfig
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2500,10 +1832,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 67
-    sourceColumn: 17
-    sourceEndLine: 71
-    sourceEndColumn: 1
   - id: SYM-ToolsRuntime
     title: ToolsRuntime
     sourceFile: packages/mcp/src/server/tools.ts
@@ -2516,10 +1844,6 @@ symbols:
         target: TEST-005
       - type: covered_by
         target: TEST-mcp-upsert-coverage
-    sourceLine: 121
-    sourceColumn: 17
-    sourceEndLine: 161
-    sourceEndColumn: 1
   - id: SYM-TOOLS
     title: TOOLS
     sourceFile: packages/mcp/src/tools-config.ts
@@ -2535,10 +1859,6 @@ symbols:
         target: TEST-005
       - type: covered_by
         target: TEST-mcp-suggest-predicates
-    sourceLine: 918
-    sourceColumn: 13
-    sourceEndLine: 920
-    sourceEndColumn: 32
   - id: SYM-withDiagnosticTelemetrySchema
     title: withDiagnosticTelemetrySchema
     sourceFile: packages/mcp/src/tools-config.ts
@@ -2549,10 +1869,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 892
-    sourceColumn: 16
-    sourceEndLine: 912
-    sourceEndColumn: 1
   - id: SYM-buildTypedMarkdownCandidates
     title: buildTypedMarkdownCandidates
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2561,10 +1877,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 210
-    sourceColumn: 16
-    sourceEndLine: 256
-    sourceEndColumn: 1
   - id: SYM-buildSymbolManifestCandidates
     title: buildSymbolManifestCandidates
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2573,10 +1885,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 259
-    sourceColumn: 16
-    sourceEndLine: 306
-    sourceEndColumn: 1
   - id: SYM-buildGenericMarkdownCandidates
     title: buildGenericMarkdownCandidates
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2585,10 +1893,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 319
-    sourceColumn: 16
-    sourceEndLine: 441
-    sourceEndColumn: 1
   - id: SYM-collectSourceOnlyAuthoringSignals
     title: collectSourceOnlyAuthoringSignals
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2597,10 +1901,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 444
-    sourceColumn: 16
-    sourceEndLine: 561
-    sourceEndColumn: 1
   - id: SYM-buildNormativeRequirementCandidates
     title: buildNormativeRequirementCandidates
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2609,10 +1909,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 564
-    sourceColumn: 16
-    sourceEndLine: 686
-    sourceEndColumn: 1
   - id: SYM-buildProviderEvidenceCandidates
     title: buildProviderEvidenceCandidates
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2621,10 +1917,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 689
-    sourceColumn: 16
-    sourceEndLine: 761
-    sourceEndColumn: 1
   - id: SYM-Candidate
     title: Candidate
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2633,10 +1925,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 25
-    sourceColumn: 17
-    sourceEndLine: 41
-    sourceEndColumn: 1
   - id: SYM-SourceOnlyAuthoringSignal
     title: SourceOnlyAuthoringSignal
     sourceFile: packages/mcp/src/tools/autopilot-candidates.ts
@@ -2645,10 +1933,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 43
-    sourceColumn: 17
-    sourceEndLine: 49
-    sourceEndColumn: 1
   - id: SYM-discoverProviderEvidence
     title: discoverProviderEvidence
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2657,10 +1941,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 956
-    sourceColumn: 16
-    sourceEndLine: 1011
-    sourceEndColumn: 1
   - id: SYM-resolveActivationPolicy
     title: resolveActivationPolicy
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2669,10 +1949,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 1072
-    sourceColumn: 22
-    sourceEndLine: 1079
-    sourceEndColumn: 1
   - id: SYM-classifyActivationState
     title: classifyActivationState
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2681,10 +1957,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 1114
-    sourceColumn: 22
-    sourceEndLine: 1180
-    sourceEndColumn: 1
   - id: SYM-discoverSources
     title: discoverSources
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2693,10 +1965,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 1223
-    sourceColumn: 16
-    sourceEndLine: 1248
-    sourceEndColumn: 1
   - id: SYM-collectMarkdownFiles
     title: collectMarkdownFiles
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2705,10 +1973,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 1183
-    sourceColumn: 16
-    sourceEndLine: 1219
-    sourceEndColumn: 1
   - id: SYM-AutopilotEvidence
     title: AutopilotEvidence
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2717,10 +1981,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 51
-    sourceColumn: 17
-    sourceEndLine: 58
-    sourceEndColumn: 1
   - id: SYM-EvidenceProviderResult
     title: EvidenceProviderResult
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2729,10 +1989,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 60
-    sourceColumn: 17
-    sourceEndLine: 67
-    sourceEndColumn: 1
   - id: SYM-DiscoverySummary
     title: DiscoverySummary
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2741,10 +1997,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 69
-    sourceColumn: 17
-    sourceEndLine: 83
-    sourceEndColumn: 1
   - id: SYM-ProviderEvidenceDiscoveryResult
     title: ProviderEvidenceDiscoveryResult
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2753,10 +2005,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 85
-    sourceColumn: 17
-    sourceEndLine: 89
-    sourceEndColumn: 1
   - id: SYM-ActivationPolicy
     title: ActivationPolicy
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2765,10 +2013,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 102
-    sourceColumn: 17
-    sourceEndLine: 109
-    sourceEndColumn: 1
   - id: SYM-SourceDiscoveryResult
     title: SourceDiscoveryResult
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2777,10 +2021,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 111
-    sourceColumn: 17
-    sourceEndLine: 115
-    sourceEndColumn: 1
   - id: SYM-ActivationState
     title: ActivationState
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2789,10 +2029,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 15
-    sourceColumn: 12
-    sourceEndLine: 20
-    sourceEndColumn: 25
   - id: SYM-ActivationMode
     title: ActivationMode
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2801,10 +2037,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 22
-    sourceColumn: 12
-    sourceEndLine: 27
-    sourceEndColumn: 23
   - id: SYM-EvidenceProviderName
     title: EvidenceProviderName
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2813,10 +2045,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 40
-    sourceColumn: 12
-    sourceEndLine: 40
-    sourceEndColumn: 77
   - id: SYM-AutopilotEvidenceKind
     title: AutopilotEvidenceKind
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2825,10 +2053,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 42
-    sourceColumn: 12
-    sourceEndLine: 49
-    sourceEndColumn: 21
   - id: SYM-AUTOPILOT-PROVIDER-ORDER
     title: AUTOPILOT_PROVIDER_ORDER
     sourceFile: packages/mcp/src/tools/autopilot-discovery.ts
@@ -2837,10 +2061,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 30
-    sourceColumn: 13
-    sourceEndLine: 38
-    sourceEndColumn: 10
   - id: SYM-handleKbAutopilotGenerate
     title: handleKbAutopilotGenerate
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2849,10 +2069,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 698
-    sourceColumn: 22
-    sourceEndLine: 1073
-    sourceEndColumn: 1
   - id: SYM-AutopilotBootstrapContext
     title: AutopilotBootstrapContext
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2861,10 +2077,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 81
-    sourceColumn: 17
-    sourceEndLine: 87
-    sourceEndColumn: 1
   - id: SYM-AutopilotConfidence
     title: AutopilotConfidence
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2873,10 +2085,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 89
-    sourceColumn: 17
-    sourceEndLine: 94
-    sourceEndColumn: 1
   - id: SYM-AutopilotRecommendedAction
     title: AutopilotRecommendedAction
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2885,10 +2093,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 96
-    sourceColumn: 17
-    sourceEndLine: 101
-    sourceEndColumn: 1
   - id: SYM-AutopilotDeclaredContext
     title: AutopilotDeclaredContext
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2897,10 +2101,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 103
-    sourceColumn: 17
-    sourceEndLine: 109
-    sourceEndColumn: 1
   - id: SYM-setAutopilotGenerateDepsForTests
     title: _setAutopilotGenerateDepsForTests
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2909,10 +2109,6 @@ symbols:
         target: REQ-mcp-init-kibi-autopilot-v1
       - type: covered_by
         target: TEST-005
-    sourceLine: 71
-    sourceColumn: 16
-    sourceEndLine: 75
-    sourceEndColumn: 1
   - id: SYM-resetAutopilotGenerateDepsForTests
     title: _resetAutopilotGenerateDepsForTests
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2921,10 +2117,6 @@ symbols:
         target: REQ-mcp-init-kibi-autopilot-v1
       - type: covered_by
         target: TEST-005
-    sourceLine: 77
-    sourceColumn: 16
-    sourceEndLine: 79
-    sourceEndColumn: 1
   - id: SYM-AutopilotGenerateArgs
     title: AutopilotGenerateArgs
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2933,10 +2125,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 111
-    sourceColumn: 17
-    sourceEndLine: 117
-    sourceEndColumn: 1
   - id: SYM-AutopilotGenerateResult
     title: AutopilotGenerateResult
     sourceFile: packages/mcp/src/tools/autopilot-generate.ts
@@ -2945,10 +2133,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 145
-    sourceColumn: 17
-    sourceEndLine: 153
-    sourceEndColumn: 1
   - id: SYM-handleKbDelete
     title: handleKbDelete
     sourceFile: packages/mcp/src/tools/delete.ts
@@ -2957,10 +2141,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 43
-    sourceColumn: 22
-    sourceEndLine: 143
-    sourceEndColumn: 1
   - id: SYM-DeleteArgs
     title: DeleteArgs
     sourceFile: packages/mcp/src/tools/delete.ts
@@ -2969,10 +2149,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 25
-    sourceColumn: 17
-    sourceEndLine: 28
-    sourceEndColumn: 1
   - id: SYM-DeleteResult
     title: DeleteResult
     sourceFile: packages/mcp/src/tools/delete.ts
@@ -2981,10 +2157,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 30
-    sourceColumn: 17
-    sourceEndLine: 37
-    sourceEndColumn: 1
   - id: SYM-estimateNormativeSignalConfidence
     title: estimateNormativeSignalConfidence
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -2993,10 +2165,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 276
-    sourceColumn: 16
-    sourceEndLine: 296
-    sourceEndColumn: 1
   - id: SYM-extractRequirementClaim
     title: extractRequirementClaim
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3005,10 +2173,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 298
-    sourceColumn: 16
-    sourceEndLine: 368
-    sourceEndColumn: 1
   - id: SYM-strictWriteSetToApplyPlan
     title: strictWriteSetToApplyPlan
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3017,10 +2181,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 380
-    sourceColumn: 16
-    sourceEndLine: 414
-    sourceEndColumn: 1
   - id: SYM-writeSetPrimaryEntityId
     title: writeSetPrimaryEntityId
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3029,10 +2189,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 416
-    sourceColumn: 16
-    sourceEndLine: 418
-    sourceEndColumn: 1
   - id: SYM-getWorkspaceMigrationWarning
     title: getWorkspaceMigrationWarning
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3041,10 +2197,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 420
-    sourceColumn: 22
-    sourceEndLine: 441
-    sourceEndColumn: 1
   - id: SYM-handleKbModelRequirement
     title: handleKbModelRequirement
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3055,10 +2207,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 443
-    sourceColumn: 22
-    sourceEndLine: 498
-    sourceEndColumn: 1
   - id: SYM-handleKbSuggestPredicates
     title: handleKbSuggestPredicates
     sourceFile: packages/mcp/src/tools/suggest-predicates.ts
@@ -3070,6 +2218,10 @@ symbols:
         target: REQ-mcp-suggest-predicates
       - type: covered_by
         target: TEST-mcp-suggest-predicates
+    sourceLine: 2910
+    sourceColumn: 22
+    sourceEndLine: 2978
+    sourceEndColumn: 1
   - id: SYM-ModelRequirementArgs
     title: ModelRequirementArgs
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3078,10 +2230,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 15
-    sourceColumn: 17
-    sourceEndLine: 25
-    sourceEndColumn: 1
   - id: SYM-ExtractedRequirementClaim
     title: ExtractedRequirementClaim
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3090,10 +2238,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 27
-    sourceColumn: 17
-    sourceEndLine: 31
-    sourceEndColumn: 1
   - id: SYM-ModelRequirementResult
     title: ModelRequirementResult
     sourceFile: packages/mcp/src/tools/model-requirement.ts
@@ -3104,10 +2248,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 33
-    sourceColumn: 17
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-SuggestPredicatesArgs
     title: SuggestPredicatesArgs
     sourceFile: packages/mcp/src/tools/suggest-predicates.ts
@@ -3119,6 +2259,10 @@ symbols:
         target: REQ-mcp-suggest-predicates
       - type: covered_by
         target: TEST-mcp-suggest-predicates
+    sourceLine: 494
+    sourceColumn: 17
+    sourceEndLine: 502
+    sourceEndColumn: 1
   - id: SYM-SuggestPredicatesResult
     title: SuggestPredicatesResult
     sourceFile: packages/mcp/src/tools/suggest-predicates.ts
@@ -3129,6 +2273,10 @@ symbols:
         target: REQ-mcp-suggest-predicates
       - type: covered_by
         target: TEST-mcp-suggest-predicates
+    sourceLine: 518
+    sourceColumn: 17
+    sourceEndLine: 532
+    sourceEndColumn: 1
   - id: SYM-handleKbSkillsList
     title: handleKbSkillsList
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3137,10 +2285,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 46
-    sourceColumn: 22
-    sourceEndLine: 62
-    sourceEndColumn: 1
   - id: SYM-handleKbSkillsLoad
     title: handleKbSkillsLoad
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3149,10 +2293,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 65
-    sourceColumn: 22
-    sourceEndLine: 95
-    sourceEndColumn: 1
   - id: SYM-handleKbSkillsRead
     title: handleKbSkillsRead
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3161,10 +2301,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 98
-    sourceColumn: 22
-    sourceEndLine: 118
-    sourceEndColumn: 1
   - id: SYM-SkillsListResult
     title: SkillsListResult
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3173,10 +2309,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 13
-    sourceColumn: 17
-    sourceEndLine: 16
-    sourceEndColumn: 1
   - id: SYM-SkillsLoadArgs
     title: SkillsLoadArgs
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3185,10 +2317,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 18
-    sourceColumn: 17
-    sourceEndLine: 20
-    sourceEndColumn: 1
   - id: SYM-SkillsLoadPayload
     title: SkillsLoadPayload
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3197,10 +2325,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 22
-    sourceColumn: 17
-    sourceEndLine: 28
-    sourceEndColumn: 1
   - id: SYM-SkillsLoadResult
     title: SkillsLoadResult
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3209,10 +2333,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 30
-    sourceColumn: 17
-    sourceEndLine: 33
-    sourceEndColumn: 1
   - id: SYM-SkillsReadArgs
     title: SkillsReadArgs
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3221,10 +2341,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 35
-    sourceColumn: 17
-    sourceEndLine: 38
-    sourceEndColumn: 1
   - id: SYM-SkillsReadResult
     title: SkillsReadResult
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3233,10 +2349,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 40
-    sourceColumn: 17
-    sourceEndLine: 43
-    sourceEndColumn: 1
   - id: SYM-SkillsListArgs
     title: SkillsListArgs
     sourceFile: packages/mcp/src/tools/skills.ts
@@ -3245,10 +2357,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 11
-    sourceColumn: 12
-    sourceEndLine: 11
-    sourceEndColumn: 51
   - id: SYM-handleKbSymbolsRefresh
     title: handleKbSymbolsRefresh
     sourceFile: packages/mcp/src/tools/symbols.ts
@@ -3257,10 +2365,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 91
-    sourceColumn: 22
-    sourceEndLine: 189
-    sourceEndColumn: 1
   - id: SYM-refreshCoordinatesForSymbolId
     title: refreshCoordinatesForSymbolId
     sourceFile: packages/mcp/src/tools/symbols.ts
@@ -3269,10 +2373,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 191
-    sourceColumn: 22
-    sourceEndLine: 265
-    sourceEndColumn: 1
   - id: SYM-resolveManifestPath
     title: resolveManifestPath
     sourceFile: packages/mcp/src/tools/symbols.ts
@@ -3281,10 +2381,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 281
-    sourceColumn: 22
-    sourceEndLine: 317
-    sourceEndColumn: 1
   - id: SYM-SymbolsRefreshArgs
     title: SymbolsRefreshArgs
     sourceFile: packages/mcp/src/tools/symbols.ts
@@ -3293,10 +2389,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 27
-    sourceColumn: 17
-    sourceEndLine: 30
-    sourceEndColumn: 1
   - id: SYM-SymbolsRefreshResult
     title: SymbolsRefreshResult
     sourceFile: packages/mcp/src/tools/symbols.ts
@@ -3305,10 +2397,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 32
-    sourceColumn: 17
-    sourceEndLine: 40
-    sourceEndColumn: 1
   - id: SYM-handleKbUpsert
     title: handleKbUpsert
     sourceFile: packages/mcp/src/tools/upsert.ts
@@ -3317,10 +2405,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 268
-    sourceColumn: 22
-    sourceEndLine: 451
-    sourceEndColumn: 1
   - id: SYM-UpsertArgs
     title: UpsertArgs
     sourceFile: packages/mcp/src/tools/upsert.ts
@@ -3329,10 +2413,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 53
-    sourceColumn: 17
-    sourceEndLine: 66
-    sourceEndColumn: 1
   - id: SYM-UpsertResult
     title: UpsertResult
     sourceFile: packages/mcp/src/tools/upsert.ts
@@ -3341,10 +2421,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 68
-    sourceColumn: 17
-    sourceEndLine: 77
-    sourceEndColumn: 1
   - id: SYM-ValidatedUpsertArgs
     title: ValidatedUpsertArgs
     sourceFile: packages/mcp/src/tools/upsert.ts
@@ -3353,10 +2429,6 @@ symbols:
         target: REQ-mcp-tool-upsert
       - type: covered_by
         target: TEST-mcp-upsert-coverage
-    sourceLine: 79
-    sourceColumn: 17
-    sourceEndLine: 82
-    sourceEndColumn: 1
   - id: SYM-validateKbUpsertArgs
     title: validateKbUpsertArgs
     sourceFile: packages/mcp/src/tools/upsert.ts
@@ -3365,10 +2437,6 @@ symbols:
         target: REQ-mcp-tool-upsert
       - type: covered_by
         target: TEST-mcp-upsert-coverage
-    sourceLine: 453
-    sourceColumn: 16
-    sourceEndLine: 500
-    sourceEndColumn: 1
   - id: SYM-test
     title: __test__
     sourceFile: packages/mcp/src/tools/upsert.ts
@@ -3377,10 +2445,6 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-005
-    sourceLine: 656
-    sourceColumn: 13
-    sourceEndLine: 663
-    sourceEndColumn: 1
   - id: SYM-ValidateUpsertResult
     title: ValidateUpsertResult
     sourceFile: packages/mcp/src/tools/validate-upsert.ts
@@ -3389,10 +2453,6 @@ symbols:
         target: REQ-mcp-tool-upsert
       - type: covered_by
         target: TEST-mcp-upsert-coverage
-    sourceLine: 6
-    sourceColumn: 17
-    sourceEndLine: 15
-    sourceEndColumn: 1
   - id: SYM-handleKbValidateUpsert
     title: handleKbValidateUpsert
     sourceFile: packages/mcp/src/tools/validate-upsert.ts
@@ -3401,10 +2461,6 @@ symbols:
         target: REQ-mcp-tool-upsert
       - type: covered_by
         target: TEST-mcp-upsert-coverage
-    sourceLine: 17
-    sourceColumn: 22
-    sourceEndLine: 58
-    sourceEndColumn: 1
   - id: SYM-validateAndMerge
     title: validateAndMerge
     sourceFile: packages/opencode/src/config.ts
@@ -3413,10 +2469,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 109
-    sourceColumn: 16
-    sourceEndLine: 223
-    sourceEndColumn: 1
   - id: SYM-loadConfig-2
     title: loadConfig
     sourceFile: packages/opencode/src/config.ts
@@ -3425,10 +2477,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 226
-    sourceColumn: 16
-    sourceEndLine: 244
-    sourceEndColumn: 1
   - id: SYM-isPluginEnabled
     title: isPluginEnabled
     sourceFile: packages/opencode/src/config.ts
@@ -3437,10 +2485,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 247
-    sourceColumn: 16
-    sourceEndLine: 250
-    sourceEndColumn: 1
   - id: SYM-KibiConfig
     title: KibiConfig
     sourceFile: packages/opencode/src/config.ts
@@ -3449,10 +2493,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 7
-    sourceColumn: 17
-    sourceEndLine: 52
-    sourceEndColumn: 1
   - id: SYM-getE2eCoverageSignal
     title: getE2eCoverageSignal
     sourceFile: packages/opencode/src/e2e-coverage-signals.ts
@@ -3461,10 +2501,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 149
-    sourceColumn: 16
-    sourceEndLine: 253
-    sourceEndColumn: 1
   - id: SYM-E2eCoverageSignal
     title: E2eCoverageSignal
     sourceFile: packages/opencode/src/e2e-coverage-signals.ts
@@ -3473,10 +2509,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 17
-    sourceEndLine: 12
-    sourceEndColumn: 1
   - id: SYM-computeEnforcementPolicy
     title: computeEnforcementPolicy
     sourceFile: packages/opencode/src/enforcement-policy.ts
@@ -3485,10 +2517,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 358
-    sourceColumn: 16
-    sourceEndLine: 449
-    sourceEndColumn: 1
   - id: SYM-PolicyLinkedEntityResult
     title: PolicyLinkedEntityResult
     sourceFile: packages/opencode/src/enforcement-policy.ts
@@ -3497,10 +2525,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 12
-    sourceColumn: 17
-    sourceEndLine: 15
-    sourceEndColumn: 1
   - id: SYM-EnforcementLifecycleEvent
     title: EnforcementLifecycleEvent
     sourceFile: packages/opencode/src/enforcement-policy.ts
@@ -3509,10 +2533,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 17
-    sourceColumn: 17
-    sourceEndLine: 20
-    sourceEndColumn: 1
   - id: SYM-EnforcementPolicyInput
     title: EnforcementPolicyInput
     sourceFile: packages/opencode/src/enforcement-policy.ts
@@ -3521,10 +2541,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 34
-    sourceColumn: 17
-    sourceEndLine: 57
-    sourceEndColumn: 1
   - id: SYM-CheckpointEvidence
     title: CheckpointEvidence
     sourceFile: packages/opencode/src/enforcement-policy.ts
@@ -3533,10 +2549,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 22
-    sourceColumn: 12
-    sourceEndLine: 32
-    sourceEndColumn: 6
   - id: SYM-EnforcementPolicyResult
     title: EnforcementPolicyResult
     sourceFile: packages/opencode/src/enforcement-policy.ts
@@ -3545,10 +2557,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 72
-    sourceColumn: 12
-    sourceEndLine: 91
-    sourceEndColumn: 7
   - id: SYM-buildEnforcementScopeKey
     title: buildEnforcementScopeKey
     sourceFile: packages/opencode/src/enforcement-scope.ts
@@ -3557,10 +2565,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 26
-    sourceColumn: 16
-    sourceEndLine: 37
-    sourceEndColumn: 1
   - id: SYM-buildDirtyRelevantFingerprint
     title: buildDirtyRelevantFingerprint
     sourceFile: packages/opencode/src/enforcement-scope.ts
@@ -3569,10 +2573,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 43
-    sourceColumn: 16
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-EnforcementScopeInput
     title: EnforcementScopeInput
     sourceFile: packages/opencode/src/enforcement-scope.ts
@@ -3581,10 +2581,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 6
-    sourceColumn: 17
-    sourceEndLine: 12
-    sourceEndColumn: 1
   - id: SYM-parseSymbolsYaml
     title: parseSymbolsYaml
     sourceFile: packages/opencode/src/file-entity-links.ts
@@ -3593,10 +2589,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 32
-    sourceColumn: 16
-    sourceEndLine: 133
-    sourceEndColumn: 1
   - id: SYM-getFileLinkedEntityIds
     title: getFileLinkedEntityIds
     sourceFile: packages/opencode/src/file-entity-links.ts
@@ -3605,10 +2597,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 213
-    sourceColumn: 16
-    sourceEndLine: 274
-    sourceEndColumn: 1
   - id: SYM-getFileLinkedTargetsByType
     title: getFileLinkedTargetsByType
     sourceFile: packages/opencode/src/file-entity-links.ts
@@ -3617,10 +2605,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 277
-    sourceColumn: 16
-    sourceEndLine: 306
-    sourceEndColumn: 1
   - id: SYM-SymbolsManifestRow
     title: SymbolsManifestRow
     sourceFile: packages/opencode/src/file-entity-links.ts
@@ -3629,10 +2613,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 12
-    sourceEndLine: 13
-    sourceEndColumn: 2
   - id: SYM-deriveFileOperationReminder
     title: deriveFileOperationReminder
     sourceFile: packages/opencode/src/file-operation-reminders.ts
@@ -3641,10 +2621,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 59
-    sourceColumn: 16
-    sourceEndLine: 113
-    sourceEndColumn: 1
   - id: SYM-LinkedEntityResult
     title: LinkedEntityResult
     sourceFile: packages/opencode/src/file-operation-reminders.ts
@@ -3653,10 +2629,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 18
-    sourceColumn: 17
-    sourceEndLine: 21
-    sourceEndColumn: 1
   - id: SYM-DeriveFileOperationReminderParams
     title: DeriveFileOperationReminderParams
     sourceFile: packages/opencode/src/file-operation-reminders.ts
@@ -3665,10 +2637,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 23
-    sourceColumn: 17
-    sourceEndLine: 39
-    sourceEndColumn: 1
   - id: SYM-DeriveFileOperationReminderResult
     title: DeriveFileOperationReminderResult
     sourceFile: packages/opencode/src/file-operation-reminders.ts
@@ -3677,10 +2645,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 41
-    sourceColumn: 17
-    sourceEndLine: 47
-    sourceEndColumn: 1
   - id: SYM-createFileOperationState
     title: createFileOperationState
     sourceFile: packages/opencode/src/file-operation-state.ts
@@ -3689,10 +2653,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 47
-    sourceColumn: 16
-    sourceEndLine: 195
-    sourceEndColumn: 1
   - id: SYM-PendingLifecycleEvent
     title: PendingLifecycleEvent
     sourceFile: packages/opencode/src/file-operation-state.ts
@@ -3701,10 +2661,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 15
-    sourceColumn: 17
-    sourceEndLine: 22
-    sourceEndColumn: 1
   - id: SYM-FileOperationState
     title: FileOperationState
     sourceFile: packages/opencode/src/file-operation-state.ts
@@ -3713,10 +2669,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 24
-    sourceColumn: 17
-    sourceEndLine: 41
-    sourceEndColumn: 1
   - id: SYM-FileLifecycle
     title: FileLifecycle
     sourceFile: packages/opencode/src/file-operation-state.ts
@@ -3725,10 +2677,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 7
-    sourceColumn: 12
-    sourceEndLine: 7
-    sourceEndColumn: 61
   - id: SYM-ReminderKind
     title: ReminderKind
     sourceFile: packages/opencode/src/file-operation-state.ts
@@ -3737,10 +2685,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 9
-    sourceColumn: 12
-    sourceEndLine: 13
-    sourceEndColumn: 17
   - id: SYM-buildInitKibiAlias
     title: buildInitKibiAlias
     sourceFile: packages/opencode/src/init-kibi-alias.ts
@@ -3749,10 +2693,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 14
-    sourceColumn: 16
-    sourceEndLine: 40
-    sourceEndColumn: 1
   - id: SYM-findSdkPackageJsonForPluginRoot
     title: findSdkPackageJsonForPluginRoot
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3761,10 +2701,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 178
-    sourceColumn: 16
-    sourceEndLine: 194
-    sourceEndColumn: 1
   - id: SYM-detectInitKibiCommandCapability
     title: detectInitKibiCommandCapability
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3773,10 +2709,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 265
-    sourceColumn: 16
-    sourceEndLine: 302
-    sourceEndColumn: 1
   - id: SYM-getInitKibiCommandCapability
     title: getInitKibiCommandCapability
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3785,10 +2717,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 304
-    sourceColumn: 16
-    sourceEndLine: 313
-    sourceEndColumn: 1
   - id: SYM-registerInitKibiCommand
     title: registerInitKibiCommand
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3797,10 +2725,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 315
-    sourceColumn: 16
-    sourceEndLine: 347
-    sourceEndColumn: 1
   - id: SYM-OpenCodeCommandDefinition
     title: OpenCodeCommandDefinition
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3809,10 +2733,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 12
-    sourceColumn: 17
-    sourceEndLine: 18
-    sourceEndColumn: 1
   - id: SYM-OpenCodeConfigHookInput
     title: OpenCodeConfigHookInput
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3821,10 +2741,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 20
-    sourceColumn: 17
-    sourceEndLine: 23
-    sourceEndColumn: 1
   - id: SYM-InitKibiCommandCapability
     title: InitKibiCommandCapability
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3833,10 +2749,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 25
-    sourceColumn: 12
-    sourceEndLine: 34
-    sourceEndColumn: 6
   - id: SYM-INIT-KIBI-COMMAND-NAME
     title: INIT_KIBI_COMMAND_NAME
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3845,10 +2757,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 7
-    sourceColumn: 13
-    sourceEndLine: 7
-    sourceEndColumn: 49
   - id: SYM-INIT-KIBI-COMMAND-TEMPLATE
     title: INIT_KIBI_COMMAND_TEMPLATE
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3857,10 +2765,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 13
-    sourceEndLine: 8
-    sourceEndColumn: 62
   - id: SYM-INIT-KIBI-COMMAND-DESCRIPTION
     title: INIT_KIBI_COMMAND_DESCRIPTION
     sourceFile: packages/opencode/src/init-kibi-capability.ts
@@ -3869,10 +2773,6 @@ symbols:
         target: REQ-opencode-bootstrap-nudge
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 9
-    sourceColumn: 13
-    sourceEndLine: 10
-    sourceEndColumn: 49
   - id: SYM-evaluateKbFreshness
     title: evaluateKbFreshness
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3881,10 +2781,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 68
-    sourceColumn: 16
-    sourceEndLine: 183
-    sourceEndColumn: 1
   - id: SYM-createKbFreshnessEvidenceStore
     title: createKbFreshnessEvidenceStore
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3893,10 +2789,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 250
-    sourceColumn: 16
-    sourceEndLine: 323
-    sourceEndColumn: 1
   - id: SYM-KbFreshnessEvidence
     title: KbFreshnessEvidence
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3905,10 +2797,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 29
-    sourceColumn: 17
-    sourceEndLine: 43
-    sourceEndColumn: 1
   - id: SYM-KbFreshnessEvaluation
     title: KbFreshnessEvaluation
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3917,10 +2805,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 45
-    sourceColumn: 17
-    sourceEndLine: 51
-    sourceEndColumn: 1
   - id: SYM-KbFreshnessScope
     title: KbFreshnessScope
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3929,10 +2813,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 189
-    sourceColumn: 17
-    sourceEndLine: 195
-    sourceEndColumn: 1
   - id: SYM-KbFreshnessEvidenceStore
     title: KbFreshnessEvidenceStore
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3941,10 +2821,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 225
-    sourceColumn: 17
-    sourceEndLine: 233
-    sourceEndColumn: 1
   - id: SYM-KbFreshnessDecision
     title: KbFreshnessDecision
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3953,10 +2829,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 14
-    sourceColumn: 12
-    sourceEndLine: 18
-    sourceEndColumn: 13
   - id: SYM-KbFreshnessStateKind
     title: KbFreshnessStateKind
     sourceFile: packages/opencode/src/kb-freshness-state.ts
@@ -3965,10 +2837,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 20
-    sourceColumn: 12
-    sourceEndLine: 27
-    sourceEndColumn: 19
   - id: SYM-KibiCheckpointRunner
     title: KibiCheckpointRunner
     sourceFile: packages/opencode/src/kibi-checkpoint-runner.ts
@@ -3977,10 +2845,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 85
-    sourceColumn: 13
-    sourceEndLine: 368
-    sourceEndColumn: 1
   - id: SYM-KibiCheckpointContext
     title: KibiCheckpointContext
     sourceFile: packages/opencode/src/kibi-checkpoint-runner.ts
@@ -3989,10 +2853,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 30
-    sourceColumn: 17
-    sourceEndLine: 41
-    sourceEndColumn: 1
   - id: SYM-KibiCheckpointRunnerOptions
     title: KibiCheckpointRunnerOptions
     sourceFile: packages/opencode/src/kibi-checkpoint-runner.ts
@@ -4001,10 +2861,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 43
-    sourceColumn: 17
-    sourceEndLine: 51
-    sourceEndColumn: 1
   - id: SYM-KibiCheckpointMetadata
     title: KibiCheckpointMetadata
     sourceFile: packages/opencode/src/kibi-checkpoint-runner.ts
@@ -4013,10 +2869,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 53
-    sourceColumn: 17
-    sourceEndLine: 67
-    sourceEndColumn: 1
   - id: SYM-KibiCheckpointRequestResult
     title: KibiCheckpointRequestResult
     sourceFile: packages/opencode/src/kibi-checkpoint-runner.ts
@@ -4025,10 +2877,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 69
-    sourceColumn: 12
-    sourceEndLine: 72
-    sourceEndColumn: 61
   - id: SYM-KibiCheckpointRunResult
     title: KibiCheckpointRunResult
     sourceFile: packages/opencode/src/kibi-checkpoint-runner.ts
@@ -4037,10 +2885,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 74
-    sourceColumn: 12
-    sourceEndLine: 77
-    sourceEndColumn: 55
   - id: SYM-classifyKnowledge
     title: classifyKnowledge
     sourceFile: packages/opencode/src/knowledge-classifier.ts
@@ -4049,10 +2893,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 92
-    sourceColumn: 16
-    sourceEndLine: 170
-    sourceEndColumn: 1
   - id: SYM-KnowledgeSuggestion
     title: KnowledgeSuggestion
     sourceFile: packages/opencode/src/knowledge-classifier.ts
@@ -4061,10 +2901,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 12
-    sourceEndLine: 12
-    sourceEndColumn: 2
   - id: SYM-setConsoleError
     title: _setConsoleError
     sourceFile: packages/opencode/src/logger.ts
@@ -4073,10 +2909,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 18
-    sourceColumn: 16
-    sourceEndLine: 20
-    sourceEndColumn: 1
   - id: SYM-setClient
     title: setClient
     sourceFile: packages/opencode/src/logger.ts
@@ -4085,10 +2917,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 23
-    sourceColumn: 16
-    sourceEndLine: 25
-    sourceEndColumn: 1
   - id: SYM-resetClient
     title: resetClient
     sourceFile: packages/opencode/src/logger.ts
@@ -4097,10 +2925,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 28
-    sourceColumn: 16
-    sourceEndLine: 30
-    sourceEndColumn: 1
   - id: SYM-info
     title: info
     sourceFile: packages/opencode/src/logger.ts
@@ -4109,10 +2933,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 46
-    sourceColumn: 16
-    sourceEndLine: 58
-    sourceEndColumn: 1
   - id: SYM-warn
     title: warn
     sourceFile: packages/opencode/src/logger.ts
@@ -4121,10 +2941,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 61
-    sourceColumn: 16
-    sourceEndLine: 73
-    sourceEndColumn: 1
   - id: SYM-errorStructuredOnly
     title: errorStructuredOnly
     sourceFile: packages/opencode/src/logger.ts
@@ -4133,10 +2949,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 110
-    sourceColumn: 16
-    sourceEndLine: 124
-    sourceEndColumn: 1
   - id: SYM-error
     title: error
     sourceFile: packages/opencode/src/logger.ts
@@ -4145,10 +2957,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 127
-    sourceColumn: 16
-    sourceEndLine: 140
-    sourceEndColumn: 1
   - id: SYM-PluginClient
     title: PluginClient
     sourceFile: packages/opencode/src/logger.ts
@@ -4157,10 +2965,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 3
-    sourceColumn: 17
-    sourceEndLine: 7
-    sourceEndColumn: 1
   - id: SYM-LogMetadata
     title: LogMetadata
     sourceFile: packages/opencode/src/logger.ts
@@ -4169,10 +2973,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 9
-    sourceColumn: 12
-    sourceEndLine: 9
-    sourceEndColumn: 50
   - id: SYM-FailureClassification
     title: FailureClassification
     sourceFile: packages/opencode/src/logger.ts
@@ -4181,10 +2981,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 104
-    sourceColumn: 12
-    sourceEndLine: 107
-    sourceEndColumn: 29
   - id: SYM-classifyMeaningfulChange
     title: classifyMeaningfulChange
     sourceFile: packages/opencode/src/meaningful-change-classifier.ts
@@ -4193,10 +2989,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 108
-    sourceColumn: 16
-    sourceEndLine: 145
-    sourceEndColumn: 1
   - id: SYM-MeaningfulChangeClass
     title: MeaningfulChangeClass
     sourceFile: packages/opencode/src/meaningful-change-classifier.ts
@@ -4205,10 +2997,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 14
-    sourceColumn: 12
-    sourceEndLine: 17
-    sourceEndColumn: 14
   - id: SYM-resolveCurrentBranch
     title: resolveCurrentBranch
     sourceFile: packages/opencode/src/plugin-startup.ts
@@ -4217,10 +3005,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 67
-    sourceColumn: 16
-    sourceEndLine: 85
-    sourceEndColumn: 1
   - id: SYM-runPluginStartup
     title: runPluginStartup
     sourceFile: packages/opencode/src/plugin-startup.ts
@@ -4229,10 +3013,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 96
-    sourceColumn: 22
-    sourceEndLine: 287
-    sourceEndColumn: 1
   - id: SYM-RuntimeDegradedOverlay
     title: RuntimeDegradedOverlay
     sourceFile: packages/opencode/src/plugin-startup.ts
@@ -4241,10 +3021,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 40
-    sourceColumn: 17
-    sourceEndLine: 49
-    sourceEndColumn: 1
   - id: SYM-PluginStartupContext
     title: PluginStartupContext
     sourceFile: packages/opencode/src/plugin-startup.ts
@@ -4253,10 +3029,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 51
-    sourceColumn: 17
-    sourceEndLine: 65
-    sourceEndColumn: 1
   - id: SYM-PluginInput
     title: PluginInput
     sourceFile: packages/opencode/src/plugin.ts
@@ -4265,10 +3037,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 85
-    sourceColumn: 17
-    sourceEndLine: 116
-    sourceEndColumn: 1
   - id: SYM-Hooks
     title: Hooks
     sourceFile: packages/opencode/src/plugin.ts
@@ -4277,10 +3045,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 142
-    sourceColumn: 17
-    sourceEndLine: 150
-    sourceEndColumn: 1
   - id: SYM-Plugin
     title: Plugin
     sourceFile: packages/opencode/src/plugin.ts
@@ -4289,10 +3053,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 152
-    sourceColumn: 12
-    sourceEndLine: 152
-    sourceEndColumn: 68
   - id: SYM-postureGuidance
     title: postureGuidance
     sourceFile: packages/opencode/src/prompt.ts
@@ -4301,10 +3061,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 221
-    sourceColumn: 16
-    sourceEndLine: 241
-    sourceEndColumn: 1
   - id: SYM-buildPrompt
     title: buildPrompt
     sourceFile: packages/opencode/src/prompt.ts
@@ -4313,10 +3069,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 652
-    sourceColumn: 16
-    sourceEndLine: 660
-    sourceEndColumn: 1
   - id: SYM-injectPrompt
     title: injectPrompt
     sourceFile: packages/opencode/src/prompt.ts
@@ -4325,10 +3077,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 665
-    sourceColumn: 16
-    sourceEndLine: 678
-    sourceEndColumn: 1
   - id: SYM-PromptContext
     title: PromptContext
     sourceFile: packages/opencode/src/prompt.ts
@@ -4337,10 +3085,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 109
-    sourceColumn: 17
-    sourceEndLine: 149
-    sourceEndColumn: 1
   - id: SYM-reconcileAuditEntries
     title: reconcileAuditEntries
     sourceFile: packages/opencode/src/reconcile-engine.ts
@@ -4349,10 +3093,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 112
-    sourceColumn: 16
-    sourceEndLine: 189
-    sourceEndColumn: 1
   - id: SYM-AuditEntityPayload
     title: AuditEntityPayload
     sourceFile: packages/opencode/src/reconcile-engine.ts
@@ -4361,10 +3101,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 1
-    sourceColumn: 17
-    sourceEndLine: 9
-    sourceEndColumn: 1
   - id: SYM-AuditEntry
     title: AuditEntry
     sourceFile: packages/opencode/src/reconcile-engine.ts
@@ -4373,10 +3109,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 11
-    sourceColumn: 17
-    sourceEndLine: 16
-    sourceEndColumn: 1
   - id: SYM-EntityChangeItem
     title: EntityChangeItem
     sourceFile: packages/opencode/src/reconcile-engine.ts
@@ -4385,10 +3117,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 18
-    sourceColumn: 17
-    sourceEndLine: 24
-    sourceEndColumn: 1
   - id: SYM-ReconcileResult
     title: ReconcileResult
     sourceFile: packages/opencode/src/reconcile-engine.ts
@@ -4397,10 +3125,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 26
-    sourceColumn: 17
-    sourceEndLine: 31
-    sourceEndColumn: 1
   - id: SYM-createSyncScheduler
     title: createSyncScheduler
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4409,10 +3133,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 404
-    sourceColumn: 16
-    sourceEndLine: 406
-    sourceEndColumn: 1
   - id: SYM-SyncRunMetadata
     title: SyncRunMetadata
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4421,10 +3141,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 9
-    sourceColumn: 17
-    sourceEndLine: 23
-    sourceEndColumn: 1
   - id: SYM-SchedulerOptions
     title: SchedulerOptions
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4433,10 +3149,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 40
-    sourceColumn: 17
-    sourceEndLine: 50
-    sourceEndColumn: 1
   - id: SYM-SyncScheduler
     title: SyncScheduler
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4445,10 +3157,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 58
-    sourceColumn: 17
-    sourceEndLine: 64
-    sourceEndColumn: 1
   - id: SYM-TimeoutHandle
     title: TimeoutHandle
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4457,10 +3165,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 7
-    sourceColumn: 12
-    sourceEndLine: 7
-    sourceEndColumn: 58
   - id: SYM-SyncRunnerResult
     title: SyncRunnerResult
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4469,10 +3173,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 25
-    sourceColumn: 12
-    sourceEndLine: 31
-    sourceEndColumn: 2
   - id: SYM-SyncRunner
     title: SyncRunner
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4481,10 +3181,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 33
-    sourceColumn: 12
-    sourceEndLine: 33
-    sourceEndColumn: 73
   - id: SYM-CheckRunner
     title: CheckRunner
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4493,10 +3189,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 35
-    sourceColumn: 12
-    sourceEndLine: 38
-    sourceEndColumn: 35
   - id: SYM-PendingTrigger
     title: PendingTrigger
     sourceFile: packages/opencode/src/scheduler.ts
@@ -4505,10 +3197,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 52
-    sourceColumn: 12
-    sourceEndLine: 56
-    sourceEndColumn: 2
   - id: SYM-createSessionEditState
     title: createSessionEditState
     sourceFile: packages/opencode/src/session-edit-state.ts
@@ -4517,10 +3205,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 46
-    sourceColumn: 16
-    sourceEndLine: 263
-    sourceEndColumn: 1
   - id: SYM-SessionEditEntry
     title: SessionEditEntry
     sourceFile: packages/opencode/src/session-edit-state.ts
@@ -4529,10 +3213,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 11
-    sourceColumn: 17
-    sourceEndLine: 20
-    sourceEndColumn: 1
   - id: SYM-SessionEditState
     title: SessionEditState
     sourceFile: packages/opencode/src/session-edit-state.ts
@@ -4541,10 +3221,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 22
-    sourceColumn: 17
-    sourceEndLine: 34
-    sourceEndColumn: 1
   - id: SYM-EditEventKind
     title: EditEventKind
     sourceFile: packages/opencode/src/session-edit-state.ts
@@ -4553,10 +3229,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 9
-    sourceColumn: 12
-    sourceEndLine: 9
-    sourceEndColumn: 35
   - id: SYM-getSourceLinkedRequirementIds
     title: getSourceLinkedRequirementIds
     sourceFile: packages/opencode/src/source-linked-guidance.ts
@@ -4565,10 +3237,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 13
-    sourceColumn: 16
-    sourceEndLine: 22
-    sourceEndColumn: 1
   - id: SYM-notifyStartup
     title: notifyStartup
     sourceFile: packages/opencode/src/startup-notifier.ts
@@ -4577,10 +3245,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 26
-    sourceColumn: 16
-    sourceEndLine: 139
-    sourceEndColumn: 1
   - id: SYM-StartupNotifierClient
     title: StartupNotifierClient
     sourceFile: packages/opencode/src/startup-notifier.ts
@@ -4589,10 +3253,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 10
-    sourceColumn: 12
-    sourceEndLine: 14
-    sourceEndColumn: 2
   - id: SYM-StartupNotifierConfig
     title: StartupNotifierConfig
     sourceFile: packages/opencode/src/startup-notifier.ts
@@ -4601,10 +3261,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 16
-    sourceColumn: 12
-    sourceEndLine: 21
-    sourceEndColumn: 2
   - id: SYM-sendToast
     title: sendToast
     sourceFile: packages/opencode/src/toast.ts
@@ -4613,10 +3269,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 32
-    sourceColumn: 22
-    sourceEndLine: 74
-    sourceEndColumn: 1
   - id: SYM-ToastPayload
     title: ToastPayload
     sourceFile: packages/opencode/src/toast.ts
@@ -4625,10 +3277,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 1
-    sourceColumn: 12
-    sourceEndLine: 6
-    sourceEndColumn: 2
   - id: SYM-SendToastResult
     title: SendToastResult
     sourceFile: packages/opencode/src/toast.ts
@@ -4637,10 +3285,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 12
-    sourceEndLine: 16
-    sourceEndColumn: 6
   - id: SYM-ToastCapableClient
     title: ToastCapableClient
     sourceFile: packages/opencode/src/toast.ts
@@ -4649,10 +3293,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 18
-    sourceColumn: 12
-    sourceEndLine: 29
-    sourceEndColumn: 2
   - id: SYM-ResolveWorkContextInput
     title: ResolveWorkContextInput
     sourceFile: packages/opencode/src/work-context-resolver.ts
@@ -4661,10 +3301,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 14
-    sourceColumn: 17
-    sourceEndLine: 20
-    sourceEndColumn: 1
   - id: SYM-WorkContext
     title: WorkContext
     sourceFile: packages/opencode/src/work-context-resolver.ts
@@ -4673,10 +3309,6 @@ symbols:
         target: REQ-opencode-kibi-plugin-v1
       - type: covered_by
         target: TEST-opencode-kibi-plugin-v1
-    sourceLine: 22
-    sourceColumn: 17
-    sourceEndLine: 32
-    sourceEndColumn: 1
   - id: SYM-registerTraceability
     title: registerTraceability
     sourceFile: packages/vscode/src/activation/traceability.ts
@@ -4685,10 +3317,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 28
-    sourceColumn: 16
-    sourceEndLine: 145
-    sourceEndColumn: 1
   - id: SYM-TraceabilityRegistrationResult
     title: TraceabilityRegistrationResult
     sourceFile: packages/vscode/src/activation/traceability.ts
@@ -4697,10 +3325,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 16
-    sourceColumn: 17
-    sourceEndLine: 23
-    sourceEndColumn: 1
   - id: SYM-setWorkspaceFsDepsForTests
     title: _setWorkspaceFsDepsForTests
     sourceFile: packages/vscode/src/activation/workspace.ts
@@ -4709,10 +3333,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 10
-    sourceColumn: 16
-    sourceEndLine: 14
-    sourceEndColumn: 1
   - id: SYM-resetWorkspaceFsDepsForTests
     title: _resetWorkspaceFsDepsForTests
     sourceFile: packages/vscode/src/activation/workspace.ts
@@ -4721,10 +3341,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 16
-    sourceColumn: 16
-    sourceEndLine: 18
-    sourceEndColumn: 1
   - id: SYM-resolveWorkspaceRoot
     title: resolveWorkspaceRoot
     sourceFile: packages/vscode/src/activation/workspace.ts
@@ -4733,10 +3349,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 24
-    sourceColumn: 16
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-getWorkspaceFolderUri
     title: getWorkspaceFolderUri
     sourceFile: packages/vscode/src/activation/workspace.ts
@@ -4745,10 +3357,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 61
-    sourceColumn: 16
-    sourceEndLine: 66
-    sourceEndColumn: 1
   - id: SYM-browseLinkedEntities
     title: browseLinkedEntities
     sourceFile: packages/vscode/src/codeActionProvider.ts
@@ -4757,10 +3365,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 121
-    sourceColumn: 22
-    sourceEndLine: 171
-    sourceEndColumn: 1
   - id: SYM-openFileAtLine
     title: openFileAtLine
     sourceFile: packages/vscode/src/codeActionProvider.ts
@@ -4769,10 +3373,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 176
-    sourceColumn: 22
-    sourceEndLine: 192
-    sourceEndColumn: 1
   - id: SYM-KibiCodeActionProvider
     title: KibiCodeActionProvider
     sourceFile: packages/vscode/src/codeActionProvider.ts
@@ -4781,10 +3381,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 25
-    sourceColumn: 13
-    sourceEndLine: 115
-    sourceEndColumn: 1
   - id: SYM-KibiCodeLensProvider
     title: KibiCodeLensProvider
     sourceFile: packages/vscode/src/codeLensProvider.ts
@@ -4793,10 +3389,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 40
-    sourceColumn: 13
-    sourceEndLine: 317
-    sourceEndColumn: 1
   - id: SYM-resetWorkspaceFeaturesForTests
     title: _resetWorkspaceFeaturesForTests
     sourceFile: packages/vscode/src/extension.ts
@@ -4805,10 +3397,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 31
-    sourceColumn: 16
-    sourceEndLine: 33
-    sourceEndColumn: 1
   - id: SYM-activate
     title: activate
     sourceFile: packages/vscode/src/extension.ts
@@ -4817,10 +3405,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 109
-    sourceColumn: 16
-    sourceEndLine: 135
-    sourceEndColumn: 1
   - id: SYM-deactivate
     title: deactivate
     sourceFile: packages/vscode/src/extension.ts
@@ -4829,10 +3413,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 138
-    sourceColumn: 16
-    sourceEndLine: 138
-    sourceEndColumn: 31
   - id: SYM-KIBI-CONTAINER-ID
     title: KIBI_CONTAINER_ID
     sourceFile: packages/vscode/src/extensionIds.ts
@@ -4841,10 +3421,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 2
-    sourceColumn: 13
-    sourceEndLine: 2
-    sourceEndColumn: 47
   - id: SYM-KIBI-VIEW-ID
     title: KIBI_VIEW_ID
     sourceFile: packages/vscode/src/extensionIds.ts
@@ -4853,10 +3429,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 4
-    sourceColumn: 13
-    sourceEndLine: 4
-    sourceEndColumn: 49
   - id: SYM-KIBI-REFRESH-TREE-COMMAND
     title: KIBI_REFRESH_TREE_COMMAND
     sourceFile: packages/vscode/src/extensionIds.ts
@@ -4865,10 +3437,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 6
-    sourceColumn: 13
-    sourceEndLine: 6
-    sourceEndColumn: 59
   - id: SYM-KIBI-FOCUS-KB-COMMAND
     title: KIBI_FOCUS_KB_COMMAND
     sourceFile: packages/vscode/src/extensionIds.ts
@@ -4877,10 +3445,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 8
-    sourceColumn: 13
-    sourceEndLine: 8
-    sourceEndColumn: 62
   - id: SYM-resolveSymbolsManifestPath-2
     title: resolveSymbolsManifestPath
     sourceFile: packages/vscode/src/shared/manifestResolver.ts
@@ -4889,10 +3453,6 @@ symbols:
         target: REQ-vscode-source-to-kb
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 23
-    sourceColumn: 16
-    sourceEndLine: 61
-    sourceEndColumn: 1
   - id: SYM-resolveSymbolsManifestPaths-2
     title: resolveSymbolsManifestPaths
     sourceFile: packages/vscode/src/shared/manifestResolver.ts
@@ -4901,10 +3461,6 @@ symbols:
         target: REQ-vscode-source-to-kb
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 63
-    sourceColumn: 16
-    sourceEndLine: 75
-    sourceEndColumn: 1
   - id: SYM-buildIndex
     title: buildIndex
     sourceFile: packages/vscode/src/symbolIndex.ts
@@ -4913,10 +3469,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 46
-    sourceColumn: 16
-    sourceEndLine: 114
-    sourceEndColumn: 1
   - id: SYM-queryRelationshipsViaCli
     title: queryRelationshipsViaCli
     sourceFile: packages/vscode/src/symbolIndex.ts
@@ -4925,10 +3477,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 254
-    sourceColumn: 16
-    sourceEndLine: 284
-    sourceEndColumn: 1
   - id: SYM-SymbolEntry
     title: SymbolEntry
     sourceFile: packages/vscode/src/symbolIndex.ts
@@ -4937,10 +3485,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 23
-    sourceColumn: 17
-    sourceEndLine: 35
-    sourceEndColumn: 1
   - id: SYM-SymbolIndex
     title: SymbolIndex
     sourceFile: packages/vscode/src/symbolIndex.ts
@@ -4949,10 +3493,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 37
-    sourceColumn: 17
-    sourceEndLine: 44
-    sourceEndColumn: 1
   - id: SYM-KibiTreeDataProvider
     title: KibiTreeDataProvider
     sourceFile: packages/vscode/src/treeProvider.ts
@@ -4961,10 +3501,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 174
-    sourceColumn: 13
-    sourceEndLine: 973
-    sourceEndColumn: 1
   - id: SYM-KibiTreeItem
     title: KibiTreeItem
     sourceFile: packages/vscode/src/treeProvider.ts
@@ -4973,10 +3509,6 @@ symbols:
         target: REQ-vscode-traceability
       - type: covered_by
         target: TEST-vscode-traceability
-    sourceLine: 33
-    sourceColumn: 17
-    sourceEndLine: 47
-    sourceEndColumn: 1
   - id: SYM-resolveNpmFixture
     title: resolveNpmFixture
     sourceFile: scripts/release-runner-fixture.ts
@@ -4985,10 +3517,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 30
-    sourceColumn: 16
-    sourceEndLine: 46
-    sourceEndColumn: 1
   - id: SYM-NpmFixtureLive
     title: NpmFixtureLive
     sourceFile: scripts/release-runner-fixture.ts
@@ -4997,10 +3525,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 10
-    sourceColumn: 17
-    sourceEndLine: 12
-    sourceEndColumn: 1
   - id: SYM-NpmFixtureMock
     title: NpmFixtureMock
     sourceFile: scripts/release-runner-fixture.ts
@@ -5009,10 +3533,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 14
-    sourceColumn: 17
-    sourceEndLine: 18
-    sourceEndColumn: 1
   - id: SYM-NpmFixtureResult
     title: NpmFixtureResult
     sourceFile: scripts/release-runner-fixture.ts
@@ -5021,10 +3541,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 20
-    sourceColumn: 12
-    sourceEndLine: 20
-    sourceEndColumn: 63
   - id: SYM-codex-packageName
     title: packageName
     sourceFile: packages/codex/src/index.ts
@@ -5033,6 +3549,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 2
+    sourceColumn: 13
+    sourceEndLine: 2
+    sourceEndColumn: 39
   - id: SYM-codex-adapterKind
     title: adapterKind
     sourceFile: packages/codex/src/index.ts
@@ -5041,6 +3561,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 3
+    sourceColumn: 13
+    sourceEndLine: 3
+    sourceEndColumn: 41
   - id: SYM-codex-HookEvent
     title: HookEvent
     sourceFile: packages/codex/src/hook-input.ts
@@ -5051,6 +3575,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 2
+    sourceColumn: 12
+    sourceEndLine: 2
+    sourceEndColumn: 79
   - id: SYM-codex-HookInput
     title: HookInput
     sourceFile: packages/codex/src/hook-input.ts
@@ -5061,6 +3589,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 4
+    sourceColumn: 12
+    sourceEndLine: 9
+    sourceEndColumn: 2
   - id: SYM-codex-parseHookInput
     title: parseHookInput
     sourceFile: packages/codex/src/hook-input.ts
@@ -5071,6 +3603,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 29
+    sourceColumn: 16
+    sourceEndLine: 58
+    sourceEndColumn: 1
   - id: SYM-codex-readStdin
     title: readStdin
     sourceFile: packages/codex/src/hook-input.ts
@@ -5081,6 +3617,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 60
+    sourceColumn: 22
+    sourceEndLine: 68
+    sourceEndColumn: 1
   - id: SYM-codex-parseStdinJson
     title: parseStdinJson
     sourceFile: packages/codex/src/hook-input.ts
@@ -5091,6 +3631,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 70
+    sourceColumn: 16
+    sourceEndLine: 77
+    sourceEndColumn: 1
   - id: SYM-codex-bootstrapReminder
     title: BOOTSTRAP_REMINDER
     sourceFile: packages/codex/src/messages.ts
@@ -5101,6 +3645,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 2
+    sourceColumn: 13
+    sourceEndLine: 3
+    sourceEndColumn: 164
   - id: SYM-codex-directKbEditWarning
     title: DIRECT_KB_EDIT_WARNING
     sourceFile: packages/codex/src/messages.ts
@@ -5111,6 +3659,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 5
+    sourceColumn: 13
+    sourceEndLine: 6
+    sourceEndColumn: 112
   - id: SYM-codex-freshnessReminder
     title: freshnessReminder
     sourceFile: packages/codex/src/messages.ts
@@ -5121,6 +3673,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 8
+    sourceColumn: 16
+    sourceEndLine: 19
+    sourceEndColumn: 1
   - id: SYM-codex-extractExplicitPathFields
     title: extractExplicitPathFields
     sourceFile: packages/codex/src/path-policy.ts
@@ -5131,6 +3687,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 97
+    sourceColumn: 16
+    sourceEndLine: 101
+    sourceEndColumn: 1
   - id: SYM-codex-isDirectKbPath
     title: isDirectKbPath
     sourceFile: packages/codex/src/path-policy.ts
@@ -5141,6 +3701,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 103
+    sourceColumn: 16
+    sourceEndLine: 105
+    sourceEndColumn: 1
   - id: SYM-codex-isMeaningfulTrackedPath
     title: isMeaningfulTrackedPath
     sourceFile: packages/codex/src/path-policy.ts
@@ -5151,6 +3715,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 107
+    sourceColumn: 16
+    sourceEndLine: 139
+    sourceEndColumn: 1
   - id: SYM-codex-HookState
     title: HookState
     sourceFile: packages/codex/src/hook-state.ts
@@ -5161,6 +3729,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 13
+    sourceColumn: 12
+    sourceEndLine: 15
+    sourceEndColumn: 2
   - id: SYM-codex-loadHookState
     title: loadHookState
     sourceFile: packages/codex/src/hook-state.ts
@@ -5171,6 +3743,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 132
+    sourceColumn: 16
+    sourceEndLine: 144
+    sourceEndColumn: 1
   - id: SYM-codex-saveHookState
     title: saveHookState
     sourceFile: packages/codex/src/hook-state.ts
@@ -5181,6 +3757,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 146
+    sourceColumn: 16
+    sourceEndLine: 159
+    sourceEndColumn: 1
   - id: SYM-codex-addDirtyPaths
     title: addDirtyPaths
     sourceFile: packages/codex/src/hook-state.ts
@@ -5191,6 +3771,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 161
+    sourceColumn: 16
+    sourceEndLine: 189
+    sourceEndColumn: 1
   - id: SYM-codex-clearDirtyPaths
     title: clearDirtyPaths
     sourceFile: packages/codex/src/hook-state.ts
@@ -5201,6 +3785,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 191
+    sourceColumn: 16
+    sourceEndLine: 213
+    sourceEndColumn: 1
   - id: SYM-codex-HookResult
     title: HookResult
     sourceFile: packages/codex/src/hook-runner.ts
@@ -5211,6 +3799,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 20
+    sourceColumn: 12
+    sourceEndLine: 25
+    sourceEndColumn: 2
   - id: SYM-codex-HookEnvironment
     title: HookEnvironment
     sourceFile: packages/codex/src/hook-runner.ts
@@ -5221,6 +3813,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 27
+    sourceColumn: 12
+    sourceEndLine: 29
+    sourceEndColumn: 2
   - id: SYM-codex-runHook
     title: runHook
     sourceFile: packages/codex/src/hook-runner.ts
@@ -5231,6 +3827,10 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
+    sourceLine: 49
+    sourceColumn: 22
+    sourceEndLine: 103
+    sourceEndColumn: 1
   - id: SYM-codex-hookRunnerPath
     title: hookRunnerPath
     sourceFile: packages/codex/src/hook-runner.ts
@@ -5241,10 +3841,6 @@ symbols:
         target: REQ-codex-kibi-plugin-v1
       - type: covered_by
         target: TEST-codex-kibi-plugin-v1
-    sourceLine: 124
-    sourceColumn: 13
-    sourceEndLine: 124
-    sourceEndColumn: 60
   - id: SYM-PUBLISHABLE-DIRS
     title: PUBLISHABLE_DIRS
     sourceFile: scripts/release-state.ts
@@ -5255,10 +3851,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 68
-    sourceColumn: 13
-    sourceEndLine: 75
-    sourceEndColumn: 10
   - id: SYM-ReleaseAction
     title: ReleaseAction
     sourceFile: scripts/release-state.ts
@@ -5269,10 +3861,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 29
-    sourceColumn: 12
-    sourceEndLine: 33
-    sourceEndColumn: 29
   - id: SYM-PackageInfo
     title: PackageInfo
     sourceFile: scripts/release-state.ts
@@ -5283,10 +3871,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 35
-    sourceColumn: 17
-    sourceEndLine: 40
-    sourceEndColumn: 1
   - id: SYM-ReleaseDecision
     title: ReleaseDecision
     sourceFile: scripts/release-state.ts
@@ -5297,10 +3881,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 42
-    sourceColumn: 17
-    sourceEndLine: 48
-    sourceEndColumn: 1
   - id: SYM-ReleaseContext
     title: ReleaseContext
     sourceFile: scripts/release-state.ts
@@ -5311,10 +3891,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 50
-    sourceColumn: 17
-    sourceEndLine: 63
-    sourceEndColumn: 1
   - id: SYM-determineReleaseAction
     title: determineReleaseAction
     sourceFile: scripts/release-state.ts
@@ -5325,10 +3901,6 @@ symbols:
         target: REQ-020
       - type: covered_by
         target: TEST-014
-    sourceLine: 88
-    sourceColumn: 16
-    sourceEndLine: 155
-    sourceEndColumn: 1
   - id: SYM-core-derived-chr
     title: derived_chr Prolog module derives bounded validation facts
     sourceFile: packages/core/src/derived_chr.pl
@@ -5380,6 +3952,10 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-prolog-library-adoption-mcp
+    sourceLine: 4
+    sourceColumn: 17
+    sourceEndLine: 8
+    sourceEndColumn: 1
   - id: SYM-SparqlResult
     title: SparqlResult
     sourceFile: packages/mcp/src/tools/sparql.ts
@@ -5394,6 +3970,10 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-prolog-library-adoption-mcp
+    sourceLine: 10
+    sourceColumn: 17
+    sourceEndLine: 15
+    sourceEndColumn: 1
   - id: SYM-handleSparql
     title: handleSparql
     sourceFile: packages/mcp/src/tools/sparql.ts
@@ -5408,6 +3988,10 @@ symbols:
         target: REQ-002
       - type: covered_by
         target: TEST-prolog-library-adoption-mcp
+    sourceLine: 18
+    sourceColumn: 22
+    sourceEndLine: 46
+    sourceEndColumn: 1
   - id: SYM-SYMBOL_ROLES
     title: SYMBOL_ROLES
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5419,10 +4003,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 1
-    sourceColumn: 13
-    sourceEndLine: 8
-    sourceEndColumn: 10
   - id: SYM-SymbolRole
     title: SymbolRole
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5432,10 +4012,6 @@ symbols:
         target: REQ-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-cli-symbol-behavioral-anchors
-    sourceLine: 10
-    sourceColumn: 12
-    sourceEndLine: 10
-    sourceEndColumn: 55
   - id: SYM-TRACEABILITY_RELATIONSHIP_TYPES
     title: TRACEABILITY_RELATIONSHIP_TYPES
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5447,10 +4023,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 12
-    sourceColumn: 13
-    sourceEndLine: 16
-    sourceEndColumn: 10
   - id: SYM-TraceabilityRelationshipType
     title: TraceabilityRelationshipType
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5462,10 +4034,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 18
-    sourceColumn: 12
-    sourceEndLine: 19
-    sourceEndColumn: 51
   - id: SYM-ALLOWED_GRANULARITY_REASONS
     title: ALLOWED_GRANULARITY_REASONS
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5477,10 +4045,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 21
-    sourceColumn: 13
-    sourceEndLine: 26
-    sourceEndColumn: 10
   - id: SYM-GranularityReason
     title: GranularityReason
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5490,10 +4054,6 @@ symbols:
         target: REQ-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-cli-symbol-behavioral-anchors
-    sourceLine: 28
-    sourceColumn: 12
-    sourceEndLine: 28
-    sourceEndColumn: 77
   - id: SYM-SymbolKind
     title: SymbolKind
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5503,10 +4063,6 @@ symbols:
         target: REQ-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-cli-symbol-behavioral-anchors
-    sourceLine: 30
-    sourceColumn: 12
-    sourceEndLine: 38
-    sourceEndColumn: 14
   - id: SYM-SymbolGranularitySourceSymbolKind
     title: SourceSymbolKind
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5518,10 +4074,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 40
-    sourceColumn: 12
-    sourceEndLine: 40
-    sourceEndColumn: 42
   - id: SYM-GranularSymbolCandidate
     title: GranularSymbolCandidate
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5531,10 +4083,6 @@ symbols:
         target: REQ-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-cli-symbol-behavioral-anchors
-    sourceLine: 42
-    sourceColumn: 17
-    sourceEndLine: 46
-    sourceEndColumn: 1
   - id: SYM-inferSymbolRole
     title: inferSymbolRole
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5546,10 +4094,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 55
-    sourceColumn: 16
-    sourceEndLine: 69
-    sourceEndColumn: 1
   - id: SYM-inferSymbolRoleFromKind
     title: inferSymbolRoleFromKind
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5561,10 +4105,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 71
-    sourceColumn: 13
-    sourceEndLine: 71
-    sourceEndColumn: 54
   - id: SYM-isSymbolRole
     title: isSymbolRole
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5576,10 +4116,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 73
-    sourceColumn: 16
-    sourceEndLine: 77
-    sourceEndColumn: 1
   - id: SYM-isTraceabilityRelationshipType
     title: isTraceabilityRelationshipType
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5591,10 +4127,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 79
-    sourceColumn: 16
-    sourceEndLine: 85
-    sourceEndColumn: 1
   - id: SYM-isAllowedGranularityReason
     title: isAllowedGranularityReason
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5606,10 +4138,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 87
-    sourceColumn: 16
-    sourceEndLine: 91
-    sourceEndColumn: 1
   - id: SYM-getSymbolRole
     title: getSymbolRole
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5621,10 +4149,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 93
-    sourceColumn: 16
-    sourceEndLine: 97
-    sourceEndColumn: 1
   - id: SYM-isBehavioralSymbol
     title: isBehavioralSymbol
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5636,10 +4160,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 99
-    sourceColumn: 16
-    sourceEndLine: 103
-    sourceEndColumn: 1
   - id: SYM-getBehavioralSymbolNames
     title: getBehavioralSymbolNames
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5651,10 +4171,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 105
-    sourceColumn: 16
-    sourceEndLine: 113
-    sourceEndColumn: 1
   - id: SYM-getNonBehavioralSymbolNames
     title: getNonBehavioralSymbolNames
     sourceFile: packages/cli/src/public/symbol-granularity.ts
@@ -5666,10 +4182,6 @@ symbols:
         target: TEST-cli-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-mcp-upsert-symbol-behavioral-anchors
-    sourceLine: 115
-    sourceColumn: 16
-    sourceEndLine: 125
-    sourceEndColumn: 1
   - id: SYM-createSymbolGranularityDiagnostics
     title: createSymbolGranularityDiagnostics
     sourceFile: packages/cli/src/commands/check.ts
@@ -5680,10 +4192,6 @@ symbols:
         target: REQ-symbol-behavioral-anchors
       - type: covered_by
         target: TEST-cli-symbol-behavioral-anchors
-    sourceLine: 239
-    sourceColumn: 9
-    sourceEndLine: 284
-    sourceEndColumn: 1
   - id: SYM-SEMANTIC_ADVISOR_VERSION
     title: SEMANTIC_ADVISOR_VERSION
     sourceFile: packages/mcp/src/semantic-advisor/analyze-prose.ts
@@ -5693,10 +4201,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 14
-    sourceColumn: 13
-    sourceEndLine: 14
-    sourceEndColumn: 61
   - id: SYM-analyzeSemanticAdvisorInput
     title: analyzeSemanticAdvisorInput
     sourceFile: packages/mcp/src/semantic-advisor/analyze-prose.ts
@@ -5706,10 +4210,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 2061
-    sourceColumn: 16
-    sourceEndLine: 2096
-    sourceEndColumn: 1
   - id: SYM-handleKbSemanticAdvisor
     title: handleKbSemanticAdvisor
     sourceFile: packages/mcp/src/tools/semantic-advisor.ts
@@ -5719,10 +4219,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 34
-    sourceColumn: 22
-    sourceEndLine: 66
-    sourceEndColumn: 1
   - id: SYM-SemanticAdvisorArgs
     title: SemanticAdvisorArgs
     sourceFile: packages/mcp/src/tools/semantic-advisor.ts
@@ -5732,10 +4228,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 4
-    sourceColumn: 17
-    sourceEndLine: 11
-    sourceEndColumn: 1
   - id: SYM-SemanticAdvisorToolResult
     title: SemanticAdvisorResult
     sourceFile: packages/mcp/src/tools/semantic-advisor.ts
@@ -5745,10 +4237,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 13
-    sourceColumn: 17
-    sourceEndLine: 19
-    sourceEndColumn: 1
   - id: SYM-SemanticAdvisorLane
     title: SemanticAdvisorLane
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5758,6 +4246,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 1
+    sourceColumn: 12
+    sourceEndLine: 5
+    sourceEndColumn: 11
   - id: SYM-SemanticAdvisorReadiness
     title: SemanticAdvisorReadiness
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5767,6 +4259,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 7
+    sourceColumn: 12
+    sourceEndLine: 10
+    sourceEndColumn: 21
   - id: SYM-SemanticSignalKind
     title: SemanticSignalKind
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5776,6 +4272,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 12
+    sourceColumn: 12
+    sourceEndLine: 18
+    sourceEndColumn: 23
   - id: SYM-SemanticSignal
     title: SemanticSignal
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5785,6 +4285,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 20
+    sourceColumn: 17
+    sourceEndLine: 25
+    sourceEndColumn: 1
   - id: SYM-SemanticAmbiguityWitness
     title: SemanticAmbiguityWitness
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5794,6 +4298,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 27
+    sourceColumn: 17
+    sourceEndLine: 32
+    sourceEndColumn: 1
   - id: SYM-SemanticAdvisorReceipt
     title: SemanticAdvisorReceipt
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5803,6 +4311,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 34
+    sourceColumn: 17
+    sourceEndLine: 44
+    sourceEndColumn: 1
   - id: SYM-SemanticModelingSuggestion
     title: SemanticModelingSuggestion
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5812,10 +4324,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 46
-    sourceColumn: 12
-    sourceEndLine: 50
-    sourceEndColumn: 34
   - id: SYM-SemanticStrictPropertyClaim
     title: SemanticStrictPropertyClaim
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5825,6 +4333,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 52
+    sourceColumn: 17
+    sourceEndLine: 62
+    sourceEndColumn: 1
   - id: SYM-SemanticStrictPropertySuggestion
     title: SemanticStrictPropertySuggestion
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5834,10 +4346,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 64
-    sourceColumn: 17
-    sourceEndLine: 73
-    sourceEndColumn: 1
   - id: SYM-SemanticPredicateClaim
     title: SemanticPredicateClaim
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5847,6 +4355,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 75
+    sourceColumn: 17
+    sourceEndLine: 80
+    sourceEndColumn: 1
   - id: SYM-SemanticPredicateSuggestion
     title: SemanticPredicateSuggestion
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5856,10 +4368,6 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
-    sourceLine: 82
-    sourceColumn: 17
-    sourceEndLine: 92
-    sourceEndColumn: 1
   - id: SYM-SemanticAmbiguityObservationSuggestion
     title: SemanticAmbiguityObservationSuggestion
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5869,6 +4377,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 94
+    sourceColumn: 17
+    sourceEndLine: 102
+    sourceEndColumn: 1
   - id: SYM-SemanticOntologyGapSuggestion
     title: SemanticOntologyGapSuggestion
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5878,6 +4390,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 104
+    sourceColumn: 17
+    sourceEndLine: 116
+    sourceEndColumn: 1
   - id: SYM-SemanticAdvisorInput
     title: SemanticAdvisorInput
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5887,6 +4403,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 118
+    sourceColumn: 17
+    sourceEndLine: 120
+    sourceEndColumn: 1
   - id: SYM-SemanticAdvisorResult
     title: SemanticAdvisorResult
     sourceFile: packages/mcp/src/semantic-advisor/types.ts
@@ -5896,6 +4416,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 122
+    sourceColumn: 17
+    sourceEndLine: 125
+    sourceEndColumn: 1
   - id: SYM-ProseCoverageExpectation
     title: ProseCoverageExpectation
     sourceFile: packages/mcp/src/semantic-advisor/prose-coverage-evaluator.ts
@@ -5905,6 +4429,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 4
+    sourceColumn: 17
+    sourceEndLine: 9
+    sourceEndColumn: 1
   - id: SYM-ProseCoverageCase
     title: ProseCoverageCase
     sourceFile: packages/mcp/src/semantic-advisor/prose-coverage-evaluator.ts
@@ -5914,6 +4442,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 11
+    sourceColumn: 17
+    sourceEndLine: 15
+    sourceEndColumn: 1
   - id: SYM-ProseCoverageFailure
     title: ProseCoverageFailure
     sourceFile: packages/mcp/src/semantic-advisor/prose-coverage-evaluator.ts
@@ -5923,6 +4455,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 17
+    sourceColumn: 17
+    sourceEndLine: 21
+    sourceEndColumn: 1
   - id: SYM-ProseCoverageResult
     title: ProseCoverageResult
     sourceFile: packages/mcp/src/semantic-advisor/prose-coverage-evaluator.ts
@@ -5932,6 +4468,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 23
+    sourceColumn: 17
+    sourceEndLine: 31
+    sourceEndColumn: 1
   - id: SYM-evaluateProseCoverageCorpus
     title: evaluateProseCoverageCorpus
     sourceFile: packages/mcp/src/semantic-advisor/prose-coverage-evaluator.ts
@@ -5941,6 +4481,10 @@ symbols:
         target: REQ-mcp-semantic-advisor-preflight
       - type: covered_by
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 33
+    sourceColumn: 16
+    sourceEndLine: 47
+    sourceEndColumn: 1
   - id: SYM-PROSE_COVERAGE_CORPUS
     title: PROSE_COVERAGE_CORPUS
     sourceFile: packages/mcp/tests/semantic-advisor/prose-coverage-fixture.ts
@@ -5948,6 +4492,10 @@ symbols:
     relationships:
       - type: executable_for
         target: TEST-mcp-semantic-advisor-preflight
+    sourceLine: 3
+    sourceColumn: 13
+    sourceEndLine: 340
+    sourceEndColumn: 1
   - id: SYM-cursor-packageName
     title: packageName
     sourceFile: packages/cursor/src/index.ts
@@ -5956,10 +4504,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 2
-    sourceColumn: 13
-    sourceEndLine: 2
-    sourceEndColumn: 40
   - id: SYM-cursor-adapterKind
     title: adapterKind
     sourceFile: packages/cursor/src/index.ts
@@ -5968,10 +4512,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 3
-    sourceColumn: 13
-    sourceEndLine: 3
-    sourceEndColumn: 42
   - id: SYM-cursor-HookEvent
     title: HookEvent
     sourceFile: packages/cursor/src/hook-input.ts
@@ -5982,10 +4522,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 2
-    sourceColumn: 12
-    sourceEndLine: 7
-    sourceEndColumn: 11
   - id: SYM-cursor-HookInput
     title: HookInput
     sourceFile: packages/cursor/src/hook-input.ts
@@ -5996,10 +4532,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 9
-    sourceColumn: 12
-    sourceEndLine: 16
-    sourceEndColumn: 2
   - id: SYM-cursor-parseHookInput
     title: parseHookInput
     sourceFile: packages/cursor/src/hook-input.ts
@@ -6010,10 +4542,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 45
-    sourceColumn: 16
-    sourceEndLine: 94
-    sourceEndColumn: 1
   - id: SYM-cursor-readStdin
     title: readStdin
     sourceFile: packages/cursor/src/hook-input.ts
@@ -6024,10 +4552,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 96
-    sourceColumn: 22
-    sourceEndLine: 104
-    sourceEndColumn: 1
   - id: SYM-cursor-parseStdinJson
     title: parseStdinJson
     sourceFile: packages/cursor/src/hook-input.ts
@@ -6038,10 +4562,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 106
-    sourceColumn: 16
-    sourceEndLine: 113
-    sourceEndColumn: 1
   - id: SYM-cursor-readGuidance
     title: readGuidance
     sourceFile: packages/cursor/src/guidance.ts
@@ -6052,10 +4572,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 16
-    sourceEndLine: 27
-    sourceEndColumn: 1
   - id: SYM-cursor-writeGuidance
     title: writeGuidance
     sourceFile: packages/cursor/src/guidance.ts
@@ -6066,10 +4582,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 29
-    sourceColumn: 16
-    sourceEndLine: 56
-    sourceEndColumn: 1
   - id: SYM-cursor-BOOTSTRAP_REMINDER
     title: BOOTSTRAP_REMINDER
     sourceFile: packages/cursor/src/messages.ts
@@ -6080,10 +4592,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 2
-    sourceColumn: 13
-    sourceEndLine: 3
-    sourceEndColumn: 164
   - id: SYM-cursor-DIRECT_KB_EDIT_WARNING
     title: DIRECT_KB_EDIT_WARNING
     sourceFile: packages/cursor/src/messages.ts
@@ -6094,10 +4602,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 5
-    sourceColumn: 13
-    sourceEndLine: 6
-    sourceEndColumn: 112
   - id: SYM-cursor-freshnessReminder
     title: freshnessReminder
     sourceFile: packages/cursor/src/messages.ts
@@ -6108,10 +4612,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 8
-    sourceColumn: 16
-    sourceEndLine: 19
-    sourceEndColumn: 1
   - id: SYM-cursor-extractExplicitPathFields
     title: extractExplicitPathFields
     sourceFile: packages/cursor/src/path-policy.ts
@@ -6122,10 +4622,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 97
-    sourceColumn: 16
-    sourceEndLine: 101
-    sourceEndColumn: 1
   - id: SYM-cursor-isDirectKbPath
     title: isDirectKbPath
     sourceFile: packages/cursor/src/path-policy.ts
@@ -6136,10 +4632,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 103
-    sourceColumn: 16
-    sourceEndLine: 105
-    sourceEndColumn: 1
   - id: SYM-cursor-isMeaningfulTrackedPath
     title: isMeaningfulTrackedPath
     sourceFile: packages/cursor/src/path-policy.ts
@@ -6150,10 +4642,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 107
-    sourceColumn: 16
-    sourceEndLine: 139
-    sourceEndColumn: 1
   - id: SYM-cursor-isDocumentationTrackedPath
     title: isDocumentationTrackedPath
     sourceFile: packages/cursor/src/path-policy.ts
@@ -6164,10 +4652,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 141
-    sourceColumn: 16
-    sourceEndLine: 154
-    sourceEndColumn: 1
   - id: SYM-cursor-toRepoRelativePath
     title: toRepoRelativePath
     sourceFile: packages/cursor/src/path-policy.ts
@@ -6178,10 +4662,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 156
-    sourceColumn: 16
-    sourceEndLine: 171
-    sourceEndColumn: 1
   - id: SYM-cursor-HookState
     title: HookState
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6192,10 +4672,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 15
-    sourceColumn: 12
-    sourceEndLine: 19
-    sourceEndColumn: 2
   - id: SYM-cursor-resolveStateDir
     title: resolveStateDir
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6206,10 +4682,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 165
-    sourceColumn: 16
-    sourceEndLine: 182
-    sourceEndColumn: 1
   - id: SYM-cursor-loadHookState
     title: loadHookState
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6220,10 +4692,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 184
-    sourceColumn: 16
-    sourceEndLine: 196
-    sourceEndColumn: 1
   - id: SYM-cursor-saveHookState
     title: saveHookState
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6234,10 +4702,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 198
-    sourceColumn: 16
-    sourceEndLine: 211
-    sourceEndColumn: 1
   - id: SYM-cursor-updateHookState
     title: updateHookState
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6248,10 +4712,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 213
-    sourceColumn: 16
-    sourceEndLine: 240
-    sourceEndColumn: 1
   - id: SYM-cursor-addDirtyPaths
     title: addDirtyPaths
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6262,10 +4722,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 242
-    sourceColumn: 16
-    sourceEndLine: 252
-    sourceEndColumn: 1
   - id: SYM-cursor-rememberGuidedPath
     title: rememberGuidedPath
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6276,10 +4732,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 254
-    sourceColumn: 16
-    sourceEndLine: 277
-    sourceEndColumn: 1
   - id: SYM-cursor-hasGuidedPath
     title: hasGuidedPath
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6290,10 +4742,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 279
-    sourceColumn: 16
-    sourceEndLine: 288
-    sourceEndColumn: 1
   - id: SYM-cursor-clearDirtyPaths
     title: clearDirtyPaths
     sourceFile: packages/cursor/src/hook-state.ts
@@ -6304,10 +4752,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 290
-    sourceColumn: 16
-    sourceEndLine: 302
-    sourceEndColumn: 1
   - id: SYM-cursor-CursorHookResult
     title: CursorHookResult
     sourceFile: packages/cursor/src/hook-runner.ts
@@ -6318,10 +4762,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 29
-    sourceColumn: 12
-    sourceEndLine: 35
-    sourceEndColumn: 2
   - id: SYM-cursor-HookEnvironment
     title: HookEnvironment
     sourceFile: packages/cursor/src/hook-runner.ts
@@ -6332,10 +4772,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 37
-    sourceColumn: 12
-    sourceEndLine: 39
-    sourceEndColumn: 2
   - id: SYM-cursor-runHook
     title: runHook
     sourceFile: packages/cursor/src/hook-runner.ts
@@ -6346,10 +4782,6 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 86
-    sourceColumn: 22
-    sourceEndLine: 206
-    sourceEndColumn: 1
   - id: SYM-cursor-hookRunnerPath
     title: hookRunnerPath
     sourceFile: packages/cursor/src/hook-runner.ts
@@ -6360,7 +4792,133 @@ symbols:
         target: REQ-cursor-kibi-plugin-v1
       - type: covered_by
         target: TEST-cursor-kibi-plugin-v1
-    sourceLine: 229
-    sourceColumn: 13
-    sourceEndLine: 229
-    sourceEndColumn: 60
+  - id: SYM-cursor-stopFollowupMessage
+    title: stopFollowupMessage
+    sourceFile: packages/cursor/src/messages.ts
+    links:
+      - REQ-cursor-kibi-plugin-v1
+    relationships:
+      - type: implements
+        target: REQ-cursor-kibi-plugin-v1
+      - type: covered_by
+        target: TEST-cursor-kibi-plugin-v1
+    sourceLine: 11
+    sourceColumn: 16
+    sourceEndLine: 25
+    sourceEndColumn: 1
+  - id: SYM-cursor-isKbFreshnessRelevantPath
+    title: isKbFreshnessRelevantPath
+    sourceFile: packages/cursor/src/path-policy.ts
+    links:
+      - REQ-cursor-kibi-plugin-v1
+    relationships:
+      - type: implements
+        target: REQ-cursor-kibi-plugin-v1
+      - type: covered_by
+        target: TEST-cursor-kibi-plugin-v1
+    sourceLine: 142
+    sourceColumn: 16
+    sourceEndLine: 154
+    sourceEndColumn: 1
+  - id: SYM-cursor-extractKbMcpToolName
+    title: extractKbMcpToolName
+    sourceFile: packages/cursor/src/kb-mcp-tools.ts
+    links:
+      - REQ-cursor-kibi-plugin-v1
+    relationships:
+      - type: implements
+        target: REQ-cursor-kibi-plugin-v1
+      - type: covered_by
+        target: TEST-cursor-kibi-plugin-v1
+    sourceLine: 20
+    sourceColumn: 16
+    sourceEndLine: 49
+    sourceEndColumn: 1
+  - id: SYM-cursor-recordKbMcpTool
+    title: recordKbMcpTool
+    sourceFile: packages/cursor/src/hook-state.ts
+    links:
+      - REQ-cursor-kibi-plugin-v1
+    relationships:
+      - type: implements
+        target: REQ-cursor-kibi-plugin-v1
+      - type: covered_by
+        target: TEST-cursor-kibi-plugin-v1
+    sourceLine: 302
+    sourceColumn: 16
+    sourceEndLine: 327
+    sourceEndColumn: 1
+  - id: SYM-cursor-clearSessionHookState
+    title: clearSessionHookState
+    sourceFile: packages/cursor/src/hook-state.ts
+    links:
+      - REQ-cursor-kibi-plugin-v1
+    relationships:
+      - type: implements
+        target: REQ-cursor-kibi-plugin-v1
+      - type: covered_by
+        target: TEST-cursor-kibi-plugin-v1
+    sourceLine: 329
+    sourceColumn: 16
+    sourceEndLine: 339
+    sourceEndColumn: 1
+  - id: SYM-mcp-createIntegrationProlog
+    title: createIntegrationProlog
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    relationships:
+      - type: executable_for
+        target: TEST-mcp-upsert-coverage
+    sourceLine: 16
+    sourceColumn: 16
+    sourceEndLine: 22
+    sourceEndColumn: 1
+  - id: SYM-mcp-startIntegrationProlog
+    title: startIntegrationProlog
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    relationships:
+      - type: executable_for
+        target: TEST-mcp-upsert-coverage
+    sourceLine: 24
+    sourceColumn: 22
+    sourceEndLine: 38
+    sourceEndColumn: 1
+  - id: SYM-mcp-createTestKbDir
+    title: createTestKbDir
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    relationships:
+      - type: executable_for
+        target: TEST-mcp-upsert-coverage
+    sourceLine: 40
+    sourceColumn: 22
+    sourceEndLine: 42
+    sourceEndColumn: 1
+  - id: SYM-mcp-attachTestKb
+    title: attachTestKb
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    relationships:
+      - type: executable_for
+        target: TEST-mcp-upsert-coverage
+    sourceLine: 44
+    sourceColumn: 22
+    sourceEndLine: 49
+    sourceEndColumn: 1
+  - id: SYM-mcp-detachTestKb
+    title: detachTestKb
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    relationships:
+      - type: executable_for
+        target: TEST-mcp-upsert-coverage
+    sourceLine: 51
+    sourceColumn: 22
+    sourceEndLine: 55
+    sourceEndColumn: 1
+  - id: SYM-mcp-stopIntegrationProlog
+    title: stopIntegrationProlog
+    sourceFile: packages/mcp/tests/helpers/integration-prolog.ts
+    relationships:
+      - type: executable_for
+        target: TEST-mcp-upsert-coverage
+    sourceLine: 57
+    sourceColumn: 22
+    sourceEndLine: 64
+    sourceEndColumn: 1

--- a/packages/cursor/src/hook-runner.ts
+++ b/packages/cursor/src/hook-runner.ts
@@ -6,18 +6,20 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { readGuidance, writeGuidance } from "./guidance.js";
 import { parseHookInput, parseStdinJson, readStdin } from "./hook-input.js";
+import { extractKbMcpToolName } from "./kb-mcp-tools.js";
 import {
   addDirtyPaths,
-  clearDirtyPaths,
+  clearSessionHookState,
   hasGuidedPath,
   loadHookState,
+  recordKbMcpTool,
   rememberGuidedPath,
   resolveStateDir,
 } from "./hook-state.js";
 import {
   BOOTSTRAP_REMINDER,
   DIRECT_KB_EDIT_WARNING,
-  freshnessReminder,
+  stopFollowupMessage,
 } from "./messages.js";
 import {
   extractExplicitPathFields,
@@ -140,6 +142,11 @@ export async function runHook(
     }
 
     case "postToolUse": {
+      const kbToolName = extractKbMcpToolName(input.toolName, input.toolInput);
+      if (kbToolName) {
+        recordKbMcpTool(stateDir, kbToolName);
+      }
+
       const explicitPaths = extractExplicitPathFields(input.toolInput);
       const dirtyPaths = explicitPaths
         .map((candidate) => toRepoRelativePath(candidate, cwd))
@@ -190,11 +197,18 @@ export async function runHook(
 
     case "stop": {
       const state = loadHookState(stateDir);
-      if (state.dirtyPaths.length > 0) {
-        clearDirtyPaths(stateDir);
-        return {
-          followup_message: freshnessReminder(state.dirtyPaths),
-        };
+      const followupMessage = stopFollowupMessage(state);
+      if (followupMessage) {
+        clearSessionHookState(stateDir);
+        return { followup_message: followupMessage };
+      }
+
+      if (
+        state.dirtyPaths.length > 0 ||
+        state.kbMutationTools.length > 0 ||
+        state.kbCheckRun
+      ) {
+        clearSessionHookState(stateDir);
       }
 
       return emptyResult();

--- a/packages/cursor/src/hook-state.ts
+++ b/packages/cursor/src/hook-state.ts
@@ -16,6 +16,8 @@ export type HookState = {
   dirtyPaths: string[];
   guidedReadPaths: string[];
   guidedWritePaths: string[];
+  kbMutationTools: string[];
+  kbCheckRun: boolean;
 };
 
 function statePath(pluginData: string): string {
@@ -58,14 +60,15 @@ function mergeStringPaths(
   return [...new Set(merged)].slice(-maxGuidedPaths);
 }
 
-function mergeDirtyPaths(
-  existingPaths: readonly string[],
-  dirtyPaths: readonly string[],
-): HookState {
+const maxKbMutationTools = 20;
+
+function emptyHookState(): HookState {
   return {
-    dirtyPaths: mergeStringPaths(existingPaths, dirtyPaths).slice(-maxDirtyPaths),
+    dirtyPaths: [],
     guidedReadPaths: [],
     guidedWritePaths: [],
+    kbMutationTools: [],
+    kbCheckRun: false,
   };
 }
 
@@ -133,7 +136,7 @@ function releaseLock(pluginData: string, fileDescriptor: number): void {
 
 function coerceHookState(value: unknown): HookState {
   if (!isRecord(value)) {
-    return { dirtyPaths: [], guidedReadPaths: [], guidedWritePaths: [] };
+    return emptyHookState();
   }
 
   const dirtyPaths = Array.isArray(value.dirtyPaths)
@@ -154,11 +157,20 @@ function coerceHookState(value: unknown): HookState {
         .map(normalizePath)
         .filter((entry) => entry.length > 0)
     : [];
+  const kbMutationTools = Array.isArray(value.kbMutationTools)
+    ? value.kbMutationTools
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    : [];
+  const kbCheckRun = value.kbCheckRun === true;
 
   return {
     dirtyPaths: [...new Set(dirtyPaths)].slice(-maxDirtyPaths),
     guidedReadPaths: [...new Set(guidedReadPaths)].slice(-maxGuidedPaths),
     guidedWritePaths: [...new Set(guidedWritePaths)].slice(-maxGuidedPaths),
+    kbMutationTools: [...new Set(kbMutationTools)].slice(-maxKbMutationTools),
+    kbCheckRun,
   };
 }
 
@@ -183,7 +195,7 @@ export function resolveStateDir(
 
 export function loadHookState(stateDir: string | undefined): HookState {
   if (!stateDir) {
-    return { dirtyPaths: [], guidedReadPaths: [], guidedWritePaths: [] };
+    return emptyHookState();
   }
 
   try {
@@ -191,7 +203,7 @@ export function loadHookState(stateDir: string | undefined): HookState {
       JSON.parse(fs.readFileSync(statePath(stateDir), "utf8")),
     );
   } catch {
-    return { dirtyPaths: [], guidedReadPaths: [], guidedWritePaths: [] };
+    return emptyHookState();
   }
 }
 
@@ -287,16 +299,46 @@ export function hasGuidedPath(
   return bucket.includes(normalized);
 }
 
-export function clearDirtyPaths(stateDir: string | undefined): HookState {
-  const clearedState: HookState = {
-    dirtyPaths: [],
-    guidedReadPaths: [],
-    guidedWritePaths: [],
-  };
+export function recordKbMcpTool(
+  stateDir: string | undefined,
+  toolName: string,
+): HookState {
+  const normalized = toolName.trim();
+  if (normalized.length === 0) {
+    return loadHookState(stateDir);
+  }
+
+  return updateHookState(stateDir, (state) => {
+    if (normalized === "kb_check") {
+      return { ...state, kbCheckRun: true };
+    }
+
+    if (normalized === "kb_upsert" || normalized === "kb_delete") {
+      return {
+        ...state,
+        kbMutationTools: mergeStringPaths(state.kbMutationTools, [normalized]).slice(
+          -maxKbMutationTools,
+        ),
+      };
+    }
+
+    return state;
+  });
+}
+
+export function clearSessionHookState(
+  stateDir: string | undefined,
+): HookState {
+  const clearedState = emptyHookState();
 
   if (!stateDir) {
     return clearedState;
   }
 
   return updateHookState(stateDir, () => clearedState);
+}
+
+/** @deprecated Use clearSessionHookState */
+export function clearDirtyPaths(stateDir: string | undefined): HookState {
+  return clearSessionHookState(stateDir);
 }

--- a/packages/cursor/src/kb-mcp-tools.ts
+++ b/packages/cursor/src/kb-mcp-tools.ts
@@ -1,0 +1,49 @@
+// implements REQ-cursor-kibi-plugin-v1
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(
+  record: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+export function extractKbMcpToolName(
+  toolName: string | undefined,
+  toolInput: unknown,
+): string | undefined {
+  if (toolName) {
+    const normalized = toolName.trim();
+    if (normalized.startsWith("kb_")) {
+      return normalized;
+    }
+  }
+
+  if (!isRecord(toolInput)) {
+    return undefined;
+  }
+
+  const directTool = readString(toolInput, ["toolName", "tool_name", "name"]);
+  if (directTool?.startsWith("kb_")) {
+    return directTool;
+  }
+
+  const nestedArgs = toolInput.arguments ?? toolInput.args;
+  if (isRecord(nestedArgs)) {
+    const nestedTool = readString(nestedArgs, ["toolName", "tool_name", "name"]);
+    if (nestedTool?.startsWith("kb_")) {
+      return nestedTool;
+    }
+  }
+
+  return undefined;
+}

--- a/packages/cursor/src/messages.ts
+++ b/packages/cursor/src/messages.ts
@@ -1,19 +1,32 @@
 // implements REQ-cursor-kibi-plugin-v1
+import type { HookState } from "./hook-state.js";
+import { isKbFreshnessRelevantPath } from "./path-policy.js";
+
 export const BOOTSTRAP_REMINDER =
   "Kibi is not initialized for this workspace. Use the Kibi MCP workflow to bootstrap project memory before relying on KB lookups; do not edit .kb/ files directly.";
 
 export const DIRECT_KB_EDIT_WARNING =
   "Avoid direct edits to .kb/. Use Kibi MCP tools for KB discovery and mutations so project memory stays valid.";
 
-export function freshnessReminder(dirtyPaths: readonly string[]): string {
-  const preview = dirtyPaths.slice(0, 10).map((dirtyPath) => `- ${dirtyPath}`);
-  const remaining = dirtyPaths.length - preview.length;
-  const suffix = remaining > 0 ? [`- …and ${remaining} more`] : [];
+export function stopFollowupMessage(state: HookState): string | undefined {
+  if (state.kbMutationTools.length > 0) {
+    const tools = [...new Set(state.kbMutationTools)];
+    return `Kibi KB updated (${tools.join(", ")}).`;
+  }
 
-  return [
-    "Kibi freshness reminder: source, test, or documentation paths changed during this Cursor session.",
-    "Before finishing, use Kibi MCP tools to resolve KB freshness or record a no-impact rationale.",
-    ...preview,
-    ...suffix,
-  ].join("\n");
+  const freshnessPaths = state.dirtyPaths.filter(isKbFreshnessRelevantPath);
+  if (freshnessPaths.length === 0 || state.kbCheckRun) {
+    return undefined;
+  }
+
+  const fileCount = freshnessPaths.length;
+  const noun = fileCount === 1 ? "file" : "files";
+  return `Kibi: sync or record no-impact after ${fileCount} edited ${noun}.`;
+}
+
+/** @deprecated Use stopFollowupMessage */
+export function freshnessReminder(dirtyPaths: readonly string[]): string {
+  const fileCount = dirtyPaths.length;
+  const noun = fileCount === 1 ? "file" : "files";
+  return `Kibi: sync or record no-impact after ${fileCount} edited ${noun}.`;
 }

--- a/packages/cursor/src/path-policy.ts
+++ b/packages/cursor/src/path-policy.ts
@@ -138,6 +138,21 @@ export function isMeaningfulTrackedPath(candidate: string): boolean {
   return false;
 }
 
+/** Paths whose edits should trigger a KB freshness stop follow-up. */
+export function isKbFreshnessRelevantPath(candidate: string): boolean {
+  const segments = pathSegments(normalizePath(candidate));
+
+  if (segments.includes("documentation")) {
+    return true;
+  }
+
+  return (
+    segments[0] === "packages" &&
+    segments[1] === "core" &&
+    segments[2] === "src"
+  );
+}
+
 export function isDocumentationTrackedPath(candidate: string): boolean {
   const normalized = normalizePath(candidate);
   const segments = pathSegments(normalized);

--- a/packages/cursor/tests/hook-runner.test.ts
+++ b/packages/cursor/tests/hook-runner.test.ts
@@ -163,26 +163,86 @@ describe("Cursor hook runner", () => {
     expect(result.additional_context).toContain("Kibi write guidance");
   });
 
-  test("stop returns freshness follow-up once and clears tracked paths", async () => {
+  test("stop returns a short freshness follow-up once and clears tracked paths", async () => {
     const pluginData = createTempRoot("kibi-cursor-data-");
     tempRoots.push(pluginData);
     await runHook(
       {
         hook_event_name: "postToolUse",
         tool_name: "Write",
-        tool_input: { file_path: "docs/cursor.md" },
+        tool_input: { file_path: "documentation/requirements/REQ-cursor.md" },
       },
       { pluginData },
     );
 
     const result = await runHook({ hook_event_name: "stop" }, { pluginData });
 
-    expect(result.followup_message).toContain("Kibi freshness reminder");
-    expect(result.followup_message).toContain("docs/cursor.md");
+    expect(result.followup_message).toBe(
+      "Kibi: sync or record no-impact after 1 edited file.",
+    );
     expect(loadHookState(pluginData).dirtyPaths).toEqual([]);
     expect(await runHook({ hook_event_name: "stop" }, { pluginData })).toEqual(
       {},
     );
+  });
+
+  test("stop stays quiet for test-only edits", async () => {
+    const pluginData = createTempRoot("kibi-cursor-data-");
+    tempRoots.push(pluginData);
+    await runHook(
+      {
+        hook_event_name: "postToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: "packages/mcp/tests/tools/check.test.ts" },
+      },
+      { pluginData },
+    );
+
+    expect(await runHook({ hook_event_name: "stop" }, { pluginData })).toEqual(
+      {},
+    );
+  });
+
+  test("stop stays quiet after kb_check even when source files changed", async () => {
+    const pluginData = createTempRoot("kibi-cursor-data-");
+    tempRoots.push(pluginData);
+    await runHook(
+      {
+        hook_event_name: "postToolUse",
+        tool_name: "CallMcpTool",
+        tool_input: { toolName: "kb_check" },
+      },
+      { pluginData },
+    );
+    await runHook(
+      {
+        hook_event_name: "postToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: "packages/core/src/kb.pl" },
+      },
+      { pluginData },
+    );
+
+    expect(await runHook({ hook_event_name: "stop" }, { pluginData })).toEqual(
+      {},
+    );
+  });
+
+  test("stop summarizes KB mutations briefly", async () => {
+    const pluginData = createTempRoot("kibi-cursor-data-");
+    tempRoots.push(pluginData);
+    await runHook(
+      {
+        hook_event_name: "postToolUse",
+        tool_name: "kb_upsert",
+        tool_input: { type: "fact", id: "FACT-001" },
+      },
+      { pluginData },
+    );
+
+    const result = await runHook({ hook_event_name: "stop" }, { pluginData });
+
+    expect(result.followup_message).toBe("Kibi KB updated (kb_upsert).");
   });
 
   test("unknown hook events return empty output", async () => {

--- a/packages/cursor/tests/kb-mcp-tools.test.ts
+++ b/packages/cursor/tests/kb-mcp-tools.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { extractKbMcpToolName } from "../src/kb-mcp-tools";
+
+describe("extractKbMcpToolName", () => {
+  test("returns direct kb tool names", () => {
+    expect(extractKbMcpToolName("kb_upsert", {})).toBe("kb_upsert");
+    expect(extractKbMcpToolName("kb_check", undefined)).toBe("kb_check");
+  });
+
+  test("returns nested MCP tool names from CallMcpTool payloads", () => {
+    expect(
+      extractKbMcpToolName("CallMcpTool", {
+        toolName: "kb_delete",
+        arguments: { id: "FACT-001" },
+      }),
+    ).toBe("kb_delete");
+  });
+
+  test("ignores non-kibi tools", () => {
+    expect(extractKbMcpToolName("Shell", { command: "ls" })).toBeUndefined();
+    expect(
+      extractKbMcpToolName("CallMcpTool", { toolName: "browser_navigate" }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cursor/tests/messages.test.ts
+++ b/packages/cursor/tests/messages.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import type { HookState } from "../src/hook-state";
+import { stopFollowupMessage } from "../src/messages";
+
+function state(overrides: Partial<HookState> = {}): HookState {
+  return {
+    dirtyPaths: [],
+    guidedReadPaths: [],
+    guidedWritePaths: [],
+    kbMutationTools: [],
+    kbCheckRun: false,
+    ...overrides,
+  };
+}
+
+describe("stopFollowupMessage", () => {
+  test("returns undefined when nothing changed", () => {
+    expect(stopFollowupMessage(state())).toBeUndefined();
+  });
+
+  test("returns a short freshness nudge for KB-relevant dirty paths without KB activity", () => {
+    expect(
+      stopFollowupMessage(state({ dirtyPaths: ["packages/core/src/kb.pl"] })),
+    ).toBe("Kibi: sync or record no-impact after 1 edited file.");
+  });
+
+  test("ignores test-only dirty paths", () => {
+    expect(
+      stopFollowupMessage(
+        state({
+          dirtyPaths: [
+            "packages/mcp/tests/tools/check.test.ts",
+            "packages/cursor/tests/hook-runner.test.ts",
+          ],
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("returns undefined when kb_check already ran on dirty paths", () => {
+    expect(
+      stopFollowupMessage(
+        state({
+          dirtyPaths: ["packages/core/src/kb.pl"],
+          kbCheckRun: true,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+
+  test("returns a short KB update summary after mutations", () => {
+    expect(
+      stopFollowupMessage(
+        state({
+          kbMutationTools: ["kb_upsert", "kb_upsert"],
+        }),
+      ),
+    ).toBe("Kibi KB updated (kb_upsert).");
+  });
+});

--- a/packages/mcp/tests/helpers/integration-prolog.ts
+++ b/packages/mcp/tests/helpers/integration-prolog.ts
@@ -7,11 +7,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import {
-  PrologProcess,
-  type PrologOptions,
-  type QueryResult,
-} from "kibi-cli/prolog";
+import { PrologProcess } from "kibi-cli/prolog";
+
+type PrologOptions = ConstructorParameters<typeof PrologProcess>[0];
+type QueryResult = Awaited<ReturnType<PrologProcess["query"]>>;
 
 export function createIntegrationProlog(
   options: PrologOptions = {},

--- a/packages/mcp/tests/helpers/integration-prolog.ts
+++ b/packages/mcp/tests/helpers/integration-prolog.ts
@@ -1,0 +1,64 @@
+/**
+ * Persistent Prolog sessions for MCP integration tests that only use kb.pl
+ * predicates (check, upsert, delete, query). Tests that call discovery.pl via
+ * runJsonModuleQuery should keep Bun one-shot mode — interactive sessions can
+ * hang on discovery goals.
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  PrologProcess,
+  type PrologOptions,
+  type QueryResult,
+} from "kibi-cli/prolog";
+
+export function createIntegrationProlog(
+  options: PrologOptions = {},
+): PrologProcess {
+  const prolog = new PrologProcess(options);
+  (prolog as unknown as { useOneShotMode: boolean }).useOneShotMode = false;
+  return prolog;
+}
+
+export async function startIntegrationProlog(
+  options?: PrologOptions,
+): Promise<PrologProcess> {
+  const prolog = createIntegrationProlog(options);
+  await prolog.start();
+  const flagResult = await prolog.query(
+    "set_prolog_flag(answer_write_options, [max_depth(0), spacing(next_argument)])",
+  );
+  if (!flagResult.success) {
+    throw new Error(
+      `Failed to configure Prolog answer options: ${flagResult.error ?? "unknown"}`,
+    );
+  }
+  return prolog;
+}
+
+export async function createTestKbDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+export async function attachTestKb(
+  prolog: PrologProcess,
+  testKbPath: string,
+): Promise<QueryResult> {
+  return prolog.query(`kb_attach('${testKbPath}')`);
+}
+
+export async function detachTestKb(prolog: PrologProcess): Promise<void> {
+  if (prolog.isRunning()) {
+    await prolog.query("kb_detach");
+  }
+}
+
+export async function stopIntegrationProlog(
+  prolog: PrologProcess,
+): Promise<void> {
+  await detachTestKb(prolog);
+  if (prolog.isRunning()) {
+    await prolog.terminate();
+  }
+}

--- a/packages/mcp/tests/tools/check.test.ts
+++ b/packages/mcp/tests/tools/check.test.ts
@@ -18,44 +18,41 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { PrologProcess } from "kibi-cli/prolog";
+import type { PrologProcess } from "kibi-cli/prolog";
 import { handleKbCheck } from "../../src/tools/check.js";
 import { resolveCorePlPath } from "../../src/tools/core-module.js";
 import { handleKbUpsert } from "../../src/tools/upsert.js";
+import {
+  attachTestKb,
+  createTestKbDir,
+  detachTestKb,
+  startIntegrationProlog,
+  stopIntegrationProlog,
+} from "../helpers/integration-prolog.js";
 
 describe("MCP Check Tool Handler", () => {
   let prolog: PrologProcess;
   let testKbPath: string;
 
   beforeAll(async () => {
-    prolog = new PrologProcess();
-    await prolog.start();
-
-    await prolog.query(
-      "set_prolog_flag(answer_write_options, [max_depth(0), spacing(next_argument)])",
-    );
+    prolog = await startIntegrationProlog();
   });
 
   beforeEach(async () => {
-    testKbPath = await fs.mkdtemp(path.join(os.tmpdir(), "kibi-mcp-check-"));
-    const attachResult = await prolog.query(`kb_attach('${testKbPath}')`);
+    testKbPath = await createTestKbDir("kibi-mcp-check-");
+    const attachResult = await attachTestKb(prolog, testKbPath);
     expect(attachResult.success).toBe(true);
   });
 
   afterEach(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-    }
+    await detachTestKb(prolog);
     if (testKbPath) {
       await fs.rm(testKbPath, { recursive: true, force: true });
     }
   });
 
   afterAll(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-      await prolog.terminate();
-    }
+    await stopIntegrationProlog(prolog);
   });
 
   test("should return no violations for empty KB", async () => {

--- a/packages/mcp/tests/tools/crud.test.ts
+++ b/packages/mcp/tests/tools/crud.test.ts
@@ -9,36 +9,37 @@ import {
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PrologProcess } from "kibi-cli/prolog";
+import type { PrologProcess } from "kibi-cli/prolog";
 import { handleKbDelete } from "../../src/tools/delete.js";
 import { handleKbQuery } from "../../src/tools/query.js";
 import { handleKbUpsert } from "../../src/tools/upsert.js";
+import {
+  attachTestKb,
+  createIntegrationProlog,
+  createTestKbDir,
+  detachTestKb,
+  startIntegrationProlog,
+  stopIntegrationProlog,
+} from "../helpers/integration-prolog.js";
 
 describe("MCP CRUD Tool Handlers", () => {
   let prolog: PrologProcess;
   let testKbPath: string;
 
   beforeAll(async () => {
-    prolog = new PrologProcess();
-    await prolog.start();
-    await prolog.query(
-      "set_prolog_flag(answer_write_options, [max_depth(0), spacing(next_argument)])",
-    );
-
-    testKbPath = await fs.mkdtemp(path.join(os.tmpdir(), "kibi-mcp-crud-"));
+    prolog = await startIntegrationProlog();
+    testKbPath = await createTestKbDir("kibi-mcp-crud-");
   });
 
   beforeEach(async () => {
+    await detachTestKb(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
     await fs.mkdir(testKbPath, { recursive: true });
-    await prolog.query(`kb_attach('${testKbPath}')`);
+    await attachTestKb(prolog, testKbPath);
   });
 
   afterAll(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-      await prolog.terminate();
-    }
+    await stopIntegrationProlog(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
   });
 
@@ -336,10 +337,10 @@ describe("MCP CRUD Tool Handlers", () => {
       await prolog.query("kb_save");
       await prolog.query("kb_detach");
 
-      const restarted = new PrologProcess();
+      const restarted = createIntegrationProlog();
       try {
         await restarted.start();
-        const attach = await restarted.query(`kb_attach('${testKbPath}')`);
+        const attach = await attachTestKb(restarted, testKbPath);
         expect(attach.success).toBe(true);
 
         const byId = await handleKbQuery(restarted, { id: reqId });

--- a/packages/mcp/tests/tools/idempotency.test.ts
+++ b/packages/mcp/tests/tools/idempotency.test.ts
@@ -9,34 +9,34 @@ import {
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PrologProcess } from "kibi-cli/prolog";
+import type { PrologProcess } from "kibi-cli/prolog";
 import { handleKbUpsert } from "../../src/tools/upsert.js";
+import {
+  attachTestKb,
+  createTestKbDir,
+  detachTestKb,
+  startIntegrationProlog,
+  stopIntegrationProlog,
+} from "../helpers/integration-prolog.js";
 
 describe("KB Relationship Idempotency", () => {
   let prolog: PrologProcess;
   let testKbPath: string;
 
   beforeAll(async () => {
-    prolog = new PrologProcess();
-    await prolog.start();
-    await prolog.query(
-      "set_prolog_flag(answer_write_options, [max_depth(0), spacing(next_argument)])",
-    );
-
-    testKbPath = await fs.mkdtemp(path.join(os.tmpdir(), "kibi-idempotency-"));
+    prolog = await startIntegrationProlog();
+    testKbPath = await createTestKbDir("kibi-idempotency-");
   });
 
   beforeEach(async () => {
+    await detachTestKb(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
     await fs.mkdir(testKbPath, { recursive: true });
-    await prolog.query(`kb_attach('${testKbPath}')`);
+    await attachTestKb(prolog, testKbPath);
   });
 
   afterAll(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-      await prolog.terminate();
-    }
+    await stopIntegrationProlog(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
   });
 

--- a/packages/mcp/tests/tools/transaction-integrity.test.ts
+++ b/packages/mcp/tests/tools/transaction-integrity.test.ts
@@ -11,42 +11,40 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PrologProcess } from "kibi-cli/prolog";
+import type { PrologProcess } from "kibi-cli/prolog";
 import { handleKbCheck } from "../../src/tools/check.js";
 import { handleKbUpsert } from "../../src/tools/upsert.js";
+import {
+  attachTestKb,
+  createTestKbDir,
+  detachTestKb,
+  startIntegrationProlog,
+  stopIntegrationProlog,
+} from "../helpers/integration-prolog.js";
 
 describe("MCP transaction integrity", () => {
   let prolog: PrologProcess;
   let testKbPath: string;
 
   beforeAll(async () => {
-    prolog = new PrologProcess();
-    await prolog.start();
-    await prolog.query(
-      "set_prolog_flag(answer_write_options, [max_depth(0), spacing(next_argument)])",
-    );
+    prolog = await startIntegrationProlog();
   });
 
   beforeEach(async () => {
-    testKbPath = await fs.mkdtemp(path.join(os.tmpdir(), "kibi-mcp-tx-"));
-    const attachResult = await prolog.query(`kb_attach('${testKbPath}')`);
+    testKbPath = await createTestKbDir("kibi-mcp-tx-");
+    const attachResult = await attachTestKb(prolog, testKbPath);
     expect(attachResult.success).toBe(true);
   });
 
   afterEach(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-    }
+    await detachTestKb(prolog);
     if (testKbPath) {
       await fs.rm(testKbPath, { recursive: true, force: true });
     }
   });
 
   afterAll(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-      await prolog.terminate();
-    }
+    await stopIntegrationProlog(prolog);
   });
 
   test("failed relationship upsert should not corrupt existing entity", async () => {

--- a/packages/mcp/tests/tools/upsert-contradictions.test.ts
+++ b/packages/mcp/tests/tools/upsert-contradictions.test.ts
@@ -8,43 +8,39 @@ import {
   test,
 } from "bun:test";
 
-// One-shot mode spawns a fresh swipl process per query (~1-1.5s each).
-// Tests with 4+ sequential upserts exceed the default 5s timeout.
 setDefaultTimeout(30_000);
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PrologProcess } from "kibi-cli/prolog";
+import type { PrologProcess } from "kibi-cli/prolog";
 import { handleKbQuery } from "../../src/tools/query.js";
 import { handleKbUpsert } from "../../src/tools/upsert.js";
+import {
+  attachTestKb,
+  createTestKbDir,
+  detachTestKb,
+  startIntegrationProlog,
+  stopIntegrationProlog,
+} from "../helpers/integration-prolog.js";
 
 describe("MCP Upsert Contradictions and Typed Facts", () => {
   let prolog: PrologProcess;
   let testKbPath: string;
 
   beforeAll(async () => {
-    prolog = new PrologProcess();
-    await prolog.start();
-    await prolog.query(
-      "set_prolog_flag(answer_write_options, [max_depth(0), spacing(next_argument)])",
-    );
-
-    testKbPath = await fs.mkdtemp(path.join(os.tmpdir(), "kibi-mcp-upsert-"));
+    prolog = await startIntegrationProlog();
+    testKbPath = await createTestKbDir("kibi-mcp-upsert-");
   });
 
   beforeEach(async () => {
-    // Detach first to avoid "No permission to attach" on test 2+
-    await prolog.query("kb_detach").catch(() => {});
+    await detachTestKb(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
     await fs.mkdir(testKbPath, { recursive: true });
-    await prolog.query(`kb_attach('${testKbPath}')`);
+    await attachTestKb(prolog, testKbPath);
   });
 
   afterAll(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-      await prolog.terminate();
-    }
+    await stopIntegrationProlog(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
   });
 

--- a/packages/mcp/tests/tools/upsert-semantic-advisor.test.ts
+++ b/packages/mcp/tests/tools/upsert-semantic-advisor.test.ts
@@ -9,31 +9,34 @@ import {
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PrologProcess } from "kibi-cli/prolog";
+import type { PrologProcess } from "kibi-cli/prolog";
 import { handleKbUpsert } from "../../src/tools/upsert.js";
+import {
+  attachTestKb,
+  createTestKbDir,
+  detachTestKb,
+  startIntegrationProlog,
+  stopIntegrationProlog,
+} from "../helpers/integration-prolog.js";
 
 describe("MCP upsert semantic advisor", () => {
   let prolog: PrologProcess;
   let testKbPath: string;
 
   beforeAll(async () => {
-    prolog = new PrologProcess();
-    await prolog.start();
-    testKbPath = await fs.mkdtemp(path.join(os.tmpdir(), "kibi-mcp-advisor-"));
+    prolog = await startIntegrationProlog();
+    testKbPath = await createTestKbDir("kibi-mcp-advisor-");
   });
 
   beforeEach(async () => {
-    await prolog.query("kb_detach").catch(() => {});
+    await detachTestKb(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
     await fs.mkdir(testKbPath, { recursive: true });
-    await prolog.query(`kb_attach('${testKbPath}')`);
+    await attachTestKb(prolog, testKbPath);
   });
 
   afterAll(async () => {
-    if (prolog?.isRunning()) {
-      await prolog.query("kb_detach");
-      await prolog.terminate();
-    }
+    await stopIntegrationProlog(prolog);
     await fs.rm(testKbPath, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Reuse a persistent Prolog process in MCP kb.pl integration tests to cut suite runtime, replace verbose stop-hook freshness dumps with short KB-aware follow-ups, and include kibi-cursor in the publish workflow.