### PR TITLE
fix(cli): restore non-git main fallback for read operations

### DIFF
--- a/.changeset/fix-cli-read-non-git-branch.md
+++ b/.changeset/fix-cli-read-non-git-branch.md
@@ -1,0 +1,9 @@
+---
+"kibi-cli": patch
+---
+
+Read-only Kibi commands (`kibi query`, `kibi search`, `kibi status`, `kibi gaps`, `kibi coverage`, `kibi graph`) now work in non-git workspaces again, attaching to the `main` branch just like `kibi init` and `kibi migrate` already do. A recent branch-resolution fix for unborn git repos had removed that non-git fallback, which broke the packed-install smoke test and blocked npm publishing.
+
+- Restore the `main` fallback in the CLI operation runtime only for `NOT_A_GIT_REPO` and `GIT_NOT_AVAILABLE` contexts.
+- Keep propagating genuine git branch-resolution errors (detached HEAD, invalid branch, unknown) so read operations never silently attach to the wrong branch.
+- Add a runtime regression test pinning non-git fallback to `main` and a second test confirming real git failures still propagate.

--- a/documentation/symbol-coordinates.yaml
+++ b/documentation/symbol-coordinates.yaml
@@ -3635,7 +3635,7 @@ coordinates:
   SYM-createCliRuntime:
     sourceColumn: 16
     sourceEndColumn: 1
-    sourceEndLine: 117
+    sourceEndLine: 125
     sourceFile: packages/cli/src/runtime/cli-runtime.ts
     sourceLine: 55
   SYM-createConfigFile:

--- a/packages/cli/src/runtime/cli-runtime.test.ts
+++ b/packages/cli/src/runtime/cli-runtime.test.ts
@@ -195,11 +195,12 @@ describe("CLI operation runtime", () => {
     }
   });
 
-  test("propagates branch resolution errors instead of falling back to main", async () => {
-    // When resolveActiveBranch cannot determine the branch (e.g. not a git repo),
-    // the runtime must propagate the error rather than silently attaching to
-    // .kb/branches/main. A silent main fallback causes read-side operations to
-    // return empty results when the real branch KB exists at a different path.
+  test("falls back to main on non-git workspaces instead of failing", async () => {
+    // A non-git workspace is a supported context: kibi init and kibi migrate
+    // both resolve to "main" for NOT_A_GIT_REPO / GIT_NOT_AVAILABLE, creating
+    // .kb/branches/main. Read-side operations must attach to that same path
+    // so the packed install smoke test (`kibi init` then `kibi query req`)
+    // succeeds without a git repository.
     const events: string[] = [];
     const failingExecSync = (() => {
       throw new Error("fatal: not a git repository");
@@ -208,6 +209,36 @@ describe("CLI operation runtime", () => {
     try {
       const runtime = createCliRuntime({
         workspaceRoot: "/not-a-git-repo",
+        prolog: createManagedProlog(events),
+      });
+
+      const context = await runtime.open(readSpec);
+      await runtime.close(context, { status: "success", result: undefined });
+
+      expect(events).toContain(
+        "query:kb_attach('/not-a-git-repo/.kb/branches/main')",
+      );
+    } finally {
+      _setBranchResolverDepsForTests({
+        execSync: fakeBranchExecSync("feature/runtime"),
+      });
+    }
+  });
+
+  test("propagates branch resolution errors for real git failures", async () => {
+    // When a genuine git context cannot determine the branch (detached HEAD,
+    // invalid branch name, etc.), the runtime must propagate the error rather
+    // than silently attaching to .kb/branches/main. A silent main fallback
+    // causes read-side operations to return empty results when the real branch
+    // KB exists at a different path.
+    const events: string[] = [];
+    const detachedExecSync = (() => {
+      return "";
+    }) as unknown as typeof import("node:child_process").execSync;
+    _setBranchResolverDepsForTests({ execSync: detachedExecSync });
+    try {
+      const runtime = createCliRuntime({
+        workspaceRoot: "/detached",
         prolog: createManagedProlog(events),
       });
 
@@ -222,7 +253,7 @@ describe("CLI operation runtime", () => {
       // Prolog must still be terminated on the error path.
       expect(events).toContain("terminate");
       expect(events).not.toContain(
-        "query:kb_attach('/not-a-git-repo/.kb/branches/main')",
+        "query:kb_attach('/detached/.kb/branches/main')",
       );
     } finally {
       _setBranchResolverDepsForTests({

--- a/packages/cli/src/runtime/cli-runtime.ts
+++ b/packages/cli/src/runtime/cli-runtime.ts
@@ -87,11 +87,19 @@ export function createCliRuntime(
         if (!branch) {
           const resolved = resolveActiveBranch(root);
           if ("error" in resolved) {
-            throw new Error(
-              `Failed to resolve active branch: ${resolved.error}`,
-            );
+            const isNonGitContext =
+              resolved.code === "NOT_A_GIT_REPO" ||
+              resolved.code === "GIT_NOT_AVAILABLE";
+            if (isNonGitContext) {
+              branch = "main";
+            } else {
+              throw new Error(
+                `Failed to resolve active branch: ${resolved.error}`,
+              );
+            }
+          } else {
+            branch = resolved.branch;
           }
-          branch = resolved.branch;
         }
         const kbPath = path.join(root, ".kb", "branches", branch);
         const attached = await prolog.query(


### PR DESCRIPTION
Read-side CLI operations now attach to the main branch in non-git workspaces, matching kibi init and kibi migrate, while still propagating genuine git branch-resolution failures such as detached HEAD. A recent unborn-repo branch fix had removed the non-git fallback, which broke the packed-install smoke test and blocked npm publishing.

Adds a regression test pinning the non-git main fallback and another confirming real git failures still propagate.