### PR TITLE
ci: build cli before packed release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,6 +163,8 @@ jobs:
         with:
           name: package-tarballs
           path: packages
+      - name: Build CLI workspace for packed typecheck
+        run: bun run build:cli
       - name: Tarball content verification
         run: |
           bun test --cwd documentation/tests/e2e/packed --timeout=300000 cli-verify-tarball-core.test.ts packed-path-hygiene.test.ts


### PR DESCRIPTION
## Summary

The npm publish workflow for PR #211 reached the release gate but failed before publishing because `typecheck:e2e:packed` resolves the workspace `kibi-cli/distribution-parity` export and the fresh gate checkout had no CLI `dist/` tree.

This adds a gate-local `bun run build:cli` after downloading the release tarballs. The packed gate still tests the downloaded artifacts; the build only supplies the workspace declarations required by the TypeScript compile.

## Validation

- `bun run check`
- `bun run build:cli`
- `bun run typecheck:e2e:packed`
- packed tarball verification
- OpenCode packed behavior tests: 8 passed

Merging to `master` will re-run the protected publish workflow for the already-versioned packages.
